### PR TITLE
Improve validator

### DIFF
--- a/validator/fields_on_correct_type.go
+++ b/validator/fields_on_correct_type.go
@@ -55,7 +55,8 @@ func getSuggestedTypeNames(ctx *vctx, parent *gqlparser.Definition, name string)
 		suggestedObjectTypes = append(suggestedObjectTypes, possibleType.Name)
 
 		for _, possibleInterface := range possibleType.Interfaces {
-			if interfaceField := ctx.schema.Types[possibleInterface.Name()]; interfaceField != nil {
+			interfaceField := ctx.schema.Types[possibleInterface.Name()]
+			if interfaceField != nil && interfaceField.Field(name) != nil {
 				interfaceUsageCount[possibleInterface.Name()]++
 			}
 		}

--- a/validator/messaging.go
+++ b/validator/messaging.go
@@ -15,10 +15,20 @@ func quotedOrList(items ...string) string {
 func orList(items ...string) string {
 	var buf bytes.Buffer
 
+	if len(items) > 5 {
+		items = items[:5]
+	}
+	if len(items) == 2 {
+		buf.WriteString(items[0])
+		buf.WriteString(" or ")
+		buf.WriteString(items[1])
+		return buf.String()
+	}
+
 	for i, item := range items {
 		if i != 0 {
 			if i == len(items)-1 {
-				buf.WriteString(" or ")
+				buf.WriteString(", or ")
 			} else {
 				buf.WriteString(", ")
 			}

--- a/validator/messaging_test.go
+++ b/validator/messaging_test.go
@@ -11,15 +11,16 @@ func TestMessaging(t *testing.T) {
 		assert.Equal(t, "", orList())
 		assert.Equal(t, "A", orList("A"))
 		assert.Equal(t, "A or B", orList("A", "B"))
-		assert.Equal(t, "A, B or C", orList("A", "B", "C"))
-		assert.Equal(t, "A, B, C or D", orList("A", "B", "C", "D"))
+		assert.Equal(t, "A, B, or C", orList("A", "B", "C"))
+		assert.Equal(t, "A, B, C, or D", orList("A", "B", "C", "D"))
+		assert.Equal(t, "A, B, C, D, or E", orList("A", "B", "C", "D", "E", "F"))
 	})
 
 	t.Run("quotedOrList", func(t *testing.T) {
 		assert.Equal(t, ``, quotedOrList())
 		assert.Equal(t, `"A"`, quotedOrList("A"))
 		assert.Equal(t, `"A" or "B"`, quotedOrList("A", "B"))
-		assert.Equal(t, `"A", "B" or "C"`, quotedOrList("A", "B", "C"))
-		assert.Equal(t, `"A", "B", "C" or "D"`, quotedOrList("A", "B", "C", "D"))
+		assert.Equal(t, `"A", "B", or "C"`, quotedOrList("A", "B", "C"))
+		assert.Equal(t, `"A", "B", "C", or "D"`, quotedOrList("A", "B", "C", "D"))
 	})
 }

--- a/validator/walk.go
+++ b/validator/walk.go
@@ -62,10 +62,21 @@ func (c *vctx) walkSelection(parentDef *gqlparser.Definition, it gqlparser.Selec
 		} else {
 			def = parentDef.Field(it.Name)
 		}
+
+		beforeErr := len(c.errors)
 		for _, v := range fieldVisitors {
 			v(c, parentDef, def, &it)
 		}
+		errFound := beforeErr != len(c.errors)
+
 		for _, sel := range it.SelectionSet {
+			switch sel.(type) {
+			case gqlparser.Field:
+				if errFound {
+					// don't walk deeper selection when error was found.
+					continue
+				}
+			}
 			c.walkSelection(parentDef, sel)
 		}
 


### PR DESCRIPTION
I'm trying improve validator.
now, We are able to reduce the failing test to 1 🎉  (see below)

```
$ go test ./...
ok  	github.com/vektah/gqlparser	(cached)
ok  	github.com/vektah/gqlparser/errors	(cached)
ok  	github.com/vektah/gqlparser/lexer	(cached)
ok  	github.com/vektah/gqlparser/spec	(cached)
[{Cannot query field "Name" on type "User". Did you mean "name"? [] FieldsOnCorrectType}]
--- FAIL: TestSpec (0.00s)
    --- FAIL: TestSpec/FieldsOnCorrectType (0.00s)
        --- FAIL: TestSpec/FieldsOnCorrectType/Validate:_Fields_on_correct_type/Defined_on_implementors_but_not_on_interface (0.00s)
        	require.go:157:
        			Error Trace:	validate_test.go:72
        			Error:      	Not equal:
        			            	expected: []errors.Validation{errors.Validation{Message:"Cannot query field \"nickname\" on type \"Pet\". Did you mean to use an inline fragment on \"Dog\" or \"Cat\"?", Locations:[]errors.Location(nil), Rule:"FieldsOnCorrectType"}}
        			            	actual  : []errors.Validation{errors.Validation{Message:"Cannot query field \"nickname\" on type \"Pet\". Did you mean to use an inline fragment on \"Cat\" or \"Dog\"?", Locations:[]errors.Location(nil), Rule:"FieldsOnCorrectType"}}

        			            	Diff:
        			            	--- Expected
        			            	+++ Actual
        			            	@@ -2,3 +2,3 @@
        			            	  (errors.Validation) {
        			            	-  Message: (string) (len=102) "Cannot query field \"nickname\" on type \"Pet\". Did you mean to use an inline fragment on \"Dog\" or \"Cat\"?",
        			            	+  Message: (string) (len=102) "Cannot query field \"nickname\" on type \"Pet\". Did you mean to use an inline fragment on \"Cat\" or \"Dog\"?",
        			            	   Locations: ([]errors.Location) <nil>,
        			Test:       	TestSpec/FieldsOnCorrectType/Validate:_Fields_on_correct_type/Defined_on_implementors_but_not_on_interface
FAIL
FAIL	github.com/vektah/gqlparser/validator	0.017s
```

This test was different only `"Dog" or "Cat"` and `"Cat" or "Dog"`.
It is due to differences in the procedure of gathering types, so I do not think there is a need to stick here.

https://github.com/graphql/graphql-js/blob/926e4d80c558b107c49e9403e943086fa9b043a8/src/type/schema.js#L131-L137

[CI before](https://circleci.com/gh/vektah/gqlparser/29?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)
[CI after](https://circleci.com/gh/vektah/gqlparser/30?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)