### PR TITLE
Extract walker from validation

### DIFF
--- a/validator/error.go
+++ b/validator/error.go
@@ -6,31 +6,15 @@ import (
 	"github.com/vektah/gqlparser/errors"
 )
 
-func Error(options ...Option) errors.Validation {
-	var err errors.Validation
+type ErrorOption func(err *errors.Validation)
 
-	for _, o := range options {
-		o(&err)
-	}
-
-	return err
-}
-
-type Option func(err *errors.Validation)
-
-func Rule(rule string) Option {
-	return func(err *errors.Validation) {
-		err.Rule = rule
-	}
-}
-
-func Message(msg string, args ...interface{}) Option {
+func Message(msg string, args ...interface{}) ErrorOption {
 	return func(err *errors.Validation) {
 		err.Message = fmt.Sprintf(msg, args...)
 	}
 }
 
-func SuggestList(typed string, suggestions []string) Option {
+func SuggestList(typed string, suggestions []string) ErrorOption {
 	suggested := suggestionList(typed, suggestions)
 	return func(err *errors.Validation) {
 		if len(suggested) > 0 {
@@ -39,7 +23,7 @@ func SuggestList(typed string, suggestions []string) Option {
 	}
 }
 
-func Suggestf(suggestion string, args ...interface{}) Option {
+func Suggestf(suggestion string, args ...interface{}) ErrorOption {
 	return func(err *errors.Validation) {
 		err.Message += " Did you mean " + fmt.Sprintf(suggestion, args...) + "?"
 	}

--- a/validator/known_argument_names.go
+++ b/validator/known_argument_names.go
@@ -5,53 +5,50 @@ import (
 )
 
 func init() {
-	fieldVisitors = append(fieldVisitors, knownFieldArgumentNames)
-	directiveVisitors = append(directiveVisitors, knownDirectiveArgumentNames)
-}
+	addRule("KnownArgumentNames", func(observers *Events, addError addErrFunc) {
+		// A GraphQL field is only valid if all supplied arguments are defined by that field.
+		observers.OnField(func(walker *Walker, parentDef *gqlparser.Definition, fieldDef *gqlparser.FieldDefinition, field *gqlparser.Field) {
+			if fieldDef == nil {
+				return
+			}
+			for _, arg := range field.Arguments {
+				def := fieldDef.Arguments.ForName(arg.Name)
+				if def != nil {
+					continue
+				}
 
-// A GraphQL field is only valid if all supplied arguments are defined by that field.
-func knownFieldArgumentNames(ctx *vctx, parentDef *gqlparser.Definition, fieldDef *gqlparser.FieldDefinition, field *gqlparser.Field) {
-	if fieldDef == nil {
-		return
-	}
-	for _, arg := range field.Arguments {
-		def := fieldDef.Arguments.ForName(arg.Name)
-		if def != nil {
-			continue
-		}
+				var suggestions []string
+				for _, argDef := range fieldDef.Arguments {
+					suggestions = append(suggestions, argDef.Name)
+				}
 
-		var suggestions []string
-		for _, argDef := range fieldDef.Arguments {
-			suggestions = append(suggestions, argDef.Name)
-		}
+				addError(
+					Message(`Unknown argument "%s" on field "%s" of type "%s".`, arg.Name, field.Name, parentDef.Name),
+					SuggestList(arg.Name, suggestions),
+				)
+			}
+		})
 
-		ctx.errors = append(ctx.errors, Error(
-			Rule("KnownArgumentNames"),
-			Message(`Unknown argument "%s" on field "%s" of type "%s".`, arg.Name, field.Name, parentDef.Name),
-			SuggestList(arg.Name, suggestions),
-		))
-	}
-}
+		observers.OnDirective(func(walker *Walker, parentDef *gqlparser.Definition, directiveDef *gqlparser.DirectiveDefinition, directive *gqlparser.Directive, location gqlparser.DirectiveLocation) {
+			if directiveDef == nil {
+				return
+			}
+			for _, arg := range directive.Arguments {
+				def := directiveDef.Arguments.ForName(arg.Name)
+				if def != nil {
+					continue
+				}
 
-func knownDirectiveArgumentNames(ctx *vctx, parentDef *gqlparser.Definition, directiveDef *gqlparser.DirectiveDefinition, directive *gqlparser.Directive, location gqlparser.DirectiveLocation) {
-	if directiveDef == nil {
-		return
-	}
-	for _, arg := range directive.Arguments {
-		def := directiveDef.Arguments.ForName(arg.Name)
-		if def != nil {
-			continue
-		}
+				var suggestions []string
+				for _, argDef := range directiveDef.Arguments {
+					suggestions = append(suggestions, argDef.Name)
+				}
 
-		var suggestions []string
-		for _, argDef := range directiveDef.Arguments {
-			suggestions = append(suggestions, argDef.Name)
-		}
-
-		ctx.errors = append(ctx.errors, Error(
-			Rule("KnownArgumentNames"),
-			Message(`Unknown argument "%s" on directive "@%s".`, arg.Name, directive.Name),
-			SuggestList(arg.Name, suggestions),
-		))
-	}
+				addError(
+					Message(`Unknown argument "%s" on directive "@%s".`, arg.Name, directive.Name),
+					SuggestList(arg.Name, suggestions),
+				)
+			}
+		})
+	})
 }

--- a/validator/scalar_leafs.go
+++ b/validator/scalar_leafs.go
@@ -1,33 +1,33 @@
 package validator
 
-import "github.com/vektah/gqlparser"
+import (
+	"github.com/vektah/gqlparser"
+)
 
 func init() {
-	fieldVisitors = append(fieldVisitors, scalarLeafs)
-}
+	addRule("ScalarLeafs", func(observers *Events, addError addErrFunc) {
+		observers.OnField(func(walker *Walker, parentDef *gqlparser.Definition, fieldDef *gqlparser.FieldDefinition, field *gqlparser.Field) {
+			if fieldDef == nil {
+				return
+			}
 
-func scalarLeafs(ctx *vctx, parentDef *gqlparser.Definition, fieldDef *gqlparser.FieldDefinition, field *gqlparser.Field) {
-	if fieldDef == nil {
-		return
-	}
+			fieldType := walker.Schema.Types[fieldDef.Type.Name()]
+			if fieldType == nil {
+				return
+			}
 
-	fieldType := ctx.schema.Types[fieldDef.Type.Name()]
-	if fieldType == nil {
-		return
-	}
+			if fieldType.IsLeafType() && len(field.SelectionSet) > 0 {
+				addError(
+					Message(`Field "%s" must not have a selection since type "%s" has no subfields.`, field.Name, fieldType.Name),
+				)
+			}
 
-	if fieldType.IsLeafType() && len(field.SelectionSet) > 0 {
-		ctx.errors = append(ctx.errors, Error(
-			Rule("ScalarLeafs"),
-			Message(`Field "%s" must not have a selection since type "%s" has no subfields.`, field.Name, fieldType.Name),
-		))
-	}
-
-	if !fieldType.IsLeafType() && len(field.SelectionSet) == 0 {
-		ctx.errors = append(ctx.errors, Error(
-			Rule("ScalarLeafs"),
-			Message(`Field "%s" of type "%s" must have a selection of subfields.`, field.Name, fieldDef.Type.String()),
-			Suggestf(`"%s { ... }"`, field.Name),
-		))
-	}
+			if !fieldType.IsLeafType() && len(field.SelectionSet) == 0 {
+				addError(
+					Message(`Field "%s" of type "%s" must have a selection of subfields.`, field.Name, fieldDef.Type.String()),
+					Suggestf(`"%s { ... }"`, field.Name),
+				)
+			}
+		})
+	})
 }

--- a/validator/single_field_subscriptions.go
+++ b/validator/single_field_subscriptions.go
@@ -7,23 +7,22 @@ import (
 )
 
 func init() {
-	operationVisitor = append(operationVisitor, singleFieldSubscriptions)
-}
+	addRule("SingleFieldSubscriptions", func(observers *Events, addError addErrFunc) {
+		observers.OnOperation(func(walker *Walker, operation *gqlparser.OperationDefinition) {
+			if operation.Operation != gqlparser.Subscription {
+				return
+			}
 
-func singleFieldSubscriptions(ctx *vctx, operation *gqlparser.OperationDefinition) {
-	if operation.Operation != gqlparser.Subscription {
-		return
-	}
+			if len(operation.SelectionSet) != 1 {
+				name := "Anonymous Subscription"
+				if operation.Name != "" {
+					name = `Subscription ` + strconv.Quote(operation.Name)
+				}
 
-	if len(operation.SelectionSet) != 1 {
-		name := "Anonymous Subscription"
-		if operation.Name != "" {
-			name = `Subscription ` + strconv.Quote(operation.Name)
-		}
-
-		ctx.errors = append(ctx.errors, Error(
-			Rule("SingleFieldSubscriptions"),
-			Message(`%s must select only one top level field.`, name),
-		))
-	}
+				addError(
+					Message(`%s must select only one top level field.`, name),
+				)
+			}
+		})
+	})
 }

--- a/validator/unique_argument_names.go
+++ b/validator/unique_argument_names.go
@@ -5,30 +5,27 @@ import (
 )
 
 func init() {
-	fieldVisitors = append(fieldVisitors, uniqueFieldArgumentNames)
-	directiveVisitors = append(directiveVisitors, uniqueDirectiveArgumentNames)
+	addRule("UniqueArgumentNames", func(observers *Events, addError addErrFunc) {
+		observers.OnField(func(walker *Walker, parentDef *gqlparser.Definition, fieldDef *gqlparser.FieldDefinition, field *gqlparser.Field) {
+			checkUniqueArgs(field.Arguments, addError)
+		})
+
+		observers.OnDirective(func(walker *Walker, parentDef *gqlparser.Definition, directiveDef *gqlparser.DirectiveDefinition, directive *gqlparser.Directive, location gqlparser.DirectiveLocation) {
+			checkUniqueArgs(directive.Arguments, addError)
+		})
+	})
 }
 
-func checkUniqueArgs(ctx *vctx, args []gqlparser.Argument) {
+func checkUniqueArgs(args []gqlparser.Argument, addError addErrFunc) {
 	knownArgNames := map[string]bool{}
 
 	for _, arg := range args {
 		if knownArgNames[arg.Name] {
-			ctx.errors = append(ctx.errors, Error(
-				Rule("UniqueArgumentNames"),
+			addError(
 				Message(`There can be only one argument named "%s".`, arg.Name),
-			))
+			)
 		}
 
 		knownArgNames[arg.Name] = true
 	}
-}
-
-// A GraphQL field is only valid if all supplied arguments are defined by that field.
-func uniqueFieldArgumentNames(ctx *vctx, parentDef *gqlparser.Definition, fieldDef *gqlparser.FieldDefinition, field *gqlparser.Field) {
-	checkUniqueArgs(ctx, field.Arguments)
-}
-
-func uniqueDirectiveArgumentNames(ctx *vctx, parentDef *gqlparser.Definition, directiveDef *gqlparser.DirectiveDefinition, directive *gqlparser.Directive, location gqlparser.DirectiveLocation) {
-	checkUniqueArgs(ctx, directive.Arguments)
 }

--- a/validator/unique_directives_per_location.go
+++ b/validator/unique_directives_per_location.go
@@ -5,20 +5,18 @@ import (
 )
 
 func init() {
-	directiveListVisitors = append(directiveListVisitors, uniqueDirectivesPerLocation)
-}
+	addRule("UniqueDirectivesPerLocation", func(observers *Events, addError addErrFunc) {
+		observers.OnDirectiveList(func(walker *Walker, parentDef *gqlparser.Definition, directives []gqlparser.Directive, location gqlparser.DirectiveLocation) {
+			seen := map[string]bool{}
 
-// A GraphQL document is only valid if all directives at a given location are uniquely named.
-func uniqueDirectivesPerLocation(ctx *vctx, parentDef *gqlparser.Definition, directives []gqlparser.Directive, location gqlparser.DirectiveLocation) {
-	seen := map[string]bool{}
-
-	for _, dir := range directives {
-		if seen[dir.Name] {
-			ctx.errors = append(ctx.errors, Error(
-				Rule("UniqueDirectivesPerLocation"),
-				Message(`The directive "%s" can only be used once at this location.`, dir.Name),
-			))
-		}
-		seen[dir.Name] = true
-	}
+			for _, dir := range directives {
+				if seen[dir.Name] {
+					addError(
+						Message(`The directive "%s" can only be used once at this location.`, dir.Name),
+					)
+				}
+				seen[dir.Name] = true
+			}
+		})
+	})
 }

--- a/validator/unique_fragment_names.go
+++ b/validator/unique_fragment_names.go
@@ -5,16 +5,16 @@ import (
 )
 
 func init() {
-	fragmentVisitors = append(fragmentVisitors, uniqueFragmentNames)
-}
+	addRule("UniqueFragmentNames", func(observers *Events, addError addErrFunc) {
+		seenFragments := map[string]bool{}
 
-// A GraphQL document is only valid if all defined fragments have unique names.
-func uniqueFragmentNames(ctx *vctx, parentDef *gqlparser.Definition, fragment *gqlparser.FragmentDefinition) {
-	if ctx.seenFragments[fragment.Name] {
-		ctx.errors = append(ctx.errors, Error(
-			Rule("UniqueFragmentNames"),
-			Message(`There can be only one fragment named "%s".`, fragment.Name),
-		))
-	}
-	ctx.seenFragments[fragment.Name] = true
+		observers.OnFragment(func(walker *Walker, parentDef *gqlparser.Definition, fragment *gqlparser.FragmentDefinition) {
+			if seenFragments[fragment.Name] {
+				addError(
+					Message(`There can be only one fragment named "%s".`, fragment.Name),
+				)
+			}
+			seenFragments[fragment.Name] = true
+		})
+	})
 }

--- a/validator/validate.go
+++ b/validator/validate.go
@@ -5,14 +5,38 @@ import (
 	"github.com/vektah/gqlparser/errors"
 )
 
+type addErrFunc func(options ...ErrorOption)
+
+type ruleFunc func(observers *Events, addError addErrFunc)
+
+type rule struct {
+	name string
+	rule ruleFunc
+}
+
+var rules []rule
+
+func addRule(name string, f ruleFunc) {
+	rules = append(rules, rule{name: name, rule: f})
+}
+
 func Validate(schema *Schema, doc *QueryDocument) []errors.Validation {
-	ctx := vctx{
-		schema:        schema,
-		document:      doc,
-		seenFragments: map[string]bool{},
+	var errs []errors.Validation
+
+	observers := &Events{}
+	for i := range rules {
+		rule := rules[i]
+		rule.rule(observers, func(options ...ErrorOption) {
+			err := errors.Validation{
+				Rule: rule.name,
+			}
+			for _, o := range options {
+				o(&err)
+			}
+			errs = append(errs, err)
+		})
 	}
 
-	ctx.walk()
-
-	return ctx.errors
+	Walk(schema, doc, observers)
+	return errs
 }

--- a/validator/walk_test.go
+++ b/validator/walk_test.go
@@ -1,0 +1,29 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser"
+)
+
+func TestWalker(t *testing.T) {
+	schema, err := gqlparser.LoadSchema("type Query { name: String }\n schema { query: Query }")
+	require.Nil(t, err)
+	query, err := gqlparser.ParseQuery("{ as: name }")
+	require.Nil(t, err)
+
+	called := false
+	observers := &Events{}
+	observers.OnField(func(walker *Walker, parentDef *gqlparser.Definition, fieldDef *gqlparser.FieldDefinition, field *gqlparser.Field) {
+		called = true
+
+		require.Equal(t, "name", field.Name)
+		require.Equal(t, "as", field.Alias)
+		require.Equal(t, "Query", parentDef.Name)
+	})
+
+	Walk(schema, &query, observers)
+
+	require.True(t, called)
+}


### PR DESCRIPTION
Make the walker reusable outside of validation. This new layout makes it possible for rules to have their own state per document which is needed to implement `UniqueInputFieldNames`.