### PR TITLE
Flatten `Type`

### DIFF
--- a/ast/definition.go
+++ b/ast/definition.go
@@ -24,9 +24,9 @@ type Definition struct {
 	Description string
 	Name        string
 	Directives  []*Directive
-	Interfaces  []NamedType           // object and input object
+	Interfaces  []string              // object and input object
 	Fields      FieldList             // object and input object
-	Types       []NamedType           // union
+	Types       []string              // union
 	Values      []EnumValueDefinition // enum
 }
 
@@ -78,7 +78,7 @@ type FieldDefinition struct {
 	Name         string
 	Arguments    FieldList // only for objects
 	DefaultValue *Value    // only for input objects
-	Type         Type
+	Type         *Type
 	Directives   []*Directive
 }
 

--- a/ast/document.go
+++ b/ast/document.go
@@ -39,7 +39,7 @@ type SchemaDefinition struct {
 
 type OperationTypeDefinition struct {
 	Operation Operation
-	Type      NamedType
+	Type      string
 }
 
 type Schema struct {
@@ -62,7 +62,7 @@ func (s *Schema) GetPossibleTypes(def *Definition) []*Definition {
 	if def.Kind == Union {
 		var defs []*Definition
 		for _, t := range def.Types {
-			defs = append(defs, s.Types[t.Name()])
+			defs = append(defs, s.Types[t])
 		}
 		return defs
 	}

--- a/ast/document_test.go
+++ b/ast/document_test.go
@@ -34,21 +34,21 @@ func TestNamedTypeCompatability(t *testing.T) {
 	assert.True(t, NamedType("A").IsCompatible(NamedType("A")))
 	assert.False(t, NamedType("A").IsCompatible(NamedType("B")))
 
-	assert.True(t, ListType{NamedType("A")}.IsCompatible(ListType{NamedType("A")}))
-	assert.False(t, ListType{NamedType("A")}.IsCompatible(ListType{NamedType("B")}))
-	assert.False(t, ListType{NamedType("A")}.IsCompatible(ListType{NamedType("B")}))
+	assert.True(t, ListType(NamedType("A")).IsCompatible(ListType(NamedType("A"))))
+	assert.False(t, ListType(NamedType("A")).IsCompatible(ListType(NamedType("B"))))
+	assert.False(t, ListType(NamedType("A")).IsCompatible(ListType(NamedType("B"))))
 
-	assert.True(t, ListType{NamedType("A")}.IsCompatible(ListType{NamedType("A")}))
-	assert.False(t, ListType{NamedType("A")}.IsCompatible(ListType{NamedType("B")}))
-	assert.False(t, ListType{NamedType("A")}.IsCompatible(ListType{NamedType("B")}))
+	assert.True(t, ListType(NamedType("A")).IsCompatible(ListType(NamedType("A"))))
+	assert.False(t, ListType(NamedType("A")).IsCompatible(ListType(NamedType("B"))))
+	assert.False(t, ListType(NamedType("A")).IsCompatible(ListType(NamedType("B"))))
 
-	assert.True(t, NonNullType{NamedType("A")}.IsCompatible(NamedType("A")))
-	assert.False(t, NamedType("A").IsCompatible(NonNullType{NamedType("A")}))
+	assert.True(t, NonNullNamedType("A").IsCompatible(NamedType("A")))
+	assert.False(t, NamedType("A").IsCompatible(NonNullNamedType("A")))
 
-	assert.True(t, NonNullType{ListType{NamedType("String")}}.IsCompatible(NonNullType{ListType{NamedType("String")}}))
-	assert.True(t, NonNullType{ListType{NamedType("String")}}.IsCompatible(ListType{NamedType("String")}))
-	assert.False(t, ListType{NamedType("String")}.IsCompatible(NonNullType{ListType{NamedType("String")}}))
+	assert.True(t, NonNullListType(NamedType("String")).IsCompatible(NonNullListType(NamedType("String"))))
+	assert.True(t, NonNullListType(NamedType("String")).IsCompatible(ListType(NamedType("String"))))
+	assert.False(t, ListType(NamedType("String")).IsCompatible(NonNullListType(NamedType("String"))))
 
-	assert.True(t, ListType{NonNullType{NamedType("String")}}.IsCompatible(ListType{NamedType("String")}))
-	assert.False(t, ListType{NamedType("String")}.IsCompatible(ListType{NonNullType{NamedType("String")}}))
+	assert.True(t, ListType(NonNullNamedType("String")).IsCompatible(ListType(NamedType("String"))))
+	assert.False(t, ListType(NamedType("String")).IsCompatible(ListType(NonNullNamedType("String"))))
 }

--- a/ast/fragment.go
+++ b/ast/fragment.go
@@ -10,7 +10,7 @@ type FragmentSpread struct {
 }
 
 type InlineFragment struct {
-	TypeCondition NamedType
+	TypeCondition string
 	Directives    []*Directive
 	SelectionSet  SelectionSet
 
@@ -23,7 +23,7 @@ type FragmentDefinition struct {
 	// Note: fragment variable definitions are experimental and may be changed
 	// or removed in the future.
 	VariableDefinition VariableDefinitions
-	TypeCondition      NamedType
+	TypeCondition      string
 	Directives         []*Directive
 	SelectionSet       SelectionSet
 

--- a/ast/operation.go
+++ b/ast/operation.go
@@ -30,7 +30,7 @@ func (v VariableDefinitions) Find(name string) *VariableDefinition {
 
 type VariableDefinition struct {
 	Variable     string
-	Type         Type
+	Type         *Type
 	DefaultValue *Value
 
 	// Requires validation

--- a/ast/value.go
+++ b/ast/value.go
@@ -29,7 +29,7 @@ type Value struct {
 	// Require validation
 	Definition         *Definition
 	VariableDefinition *VariableDefinition
-	ExpectedType       Type
+	ExpectedType       *Type
 }
 
 type ChildValue struct {

--- a/parser/loader.go
+++ b/parser/loader.go
@@ -51,7 +51,7 @@ func LoadSchema(input string) (*Schema, error) {
 			FieldDefinition{
 				Name:        "if",
 				Description: "Skipped when true.",
-				Type:        NonNullType{NamedType("Boolean")},
+				Type:        NonNullNamedType("Boolean"),
 			},
 		},
 		Locations: []DirectiveLocation{LocationField, LocationFragmentSpread, LocationInlineFragment},
@@ -63,7 +63,7 @@ func LoadSchema(input string) (*Schema, error) {
 			FieldDefinition{
 				Name:        "if",
 				Description: "Included when true.",
-				Type:        NonNullType{NamedType("Boolean")},
+				Type:        NonNullNamedType("Boolean"),
 			},
 		},
 		Locations: []DirectiveLocation{LocationField, LocationFragmentSpread, LocationInlineFragment},
@@ -77,7 +77,7 @@ func LoadSchema(input string) (*Schema, error) {
 
 		if def.Kind != Interface {
 			for _, intf := range def.Interfaces {
-				schema.AddPossibleType(intf.Name(), &ast.Definitions[i])
+				schema.AddPossibleType(intf, &ast.Definitions[i])
 			}
 			schema.AddPossibleType(def.Name, &ast.Definitions[i])
 		}
@@ -113,7 +113,7 @@ func LoadSchema(input string) (*Schema, error) {
 
 	if len(ast.Schema) == 1 {
 		for _, entrypoint := range ast.Schema[0].OperationTypes {
-			def := schema.Types[entrypoint.Type.Name()]
+			def := schema.Types[entrypoint.Type]
 			if def == nil {
 				return nil, fmt.Errorf("Schema root %s refers to a type %s that does not exist.", entrypoint.Operation, entrypoint.Type)
 			}
@@ -130,7 +130,7 @@ func LoadSchema(input string) (*Schema, error) {
 
 	for _, ext := range ast.SchemaExtension {
 		for _, entrypoint := range ext.OperationTypes {
-			def := schema.Types[entrypoint.Type.Name()]
+			def := schema.Types[entrypoint.Type]
 			if def == nil {
 				return nil, fmt.Errorf("Schema root %s refers to a type %s that does not exist.", entrypoint.Operation, entrypoint.Type)
 			}

--- a/parser/query.go
+++ b/parser/query.go
@@ -176,7 +176,7 @@ func (p *parser) parseFragment() Selection {
 	if p.peek().Value == "on" {
 		p.next() // "on"
 
-		def.TypeCondition = p.parseNamedType()
+		def.TypeCondition = p.parseName()
 	}
 
 	def.Directives = p.parseDirectives(false)
@@ -193,7 +193,7 @@ func (p *parser) parseFragmentDefinition() FragmentDefinition {
 
 	p.expectKeyword("on")
 
-	def.TypeCondition = p.parseNamedType()
+	def.TypeCondition = p.parseName()
 	def.Directives = p.parseDirectives(false)
 	def.SelectionSet = p.parseSelectionSet()
 	return def
@@ -299,30 +299,20 @@ func (p *parser) parseDirective(isConst bool) *Directive {
 	}
 }
 
-func (p *parser) parseTypeReference() Type {
+func (p *parser) parseTypeReference() *Type {
 	var typ Type
 
 	if p.skip(lexer.BracketL) {
-		typ = p.parseTypeReference()
-
-		typ = ListType{
-			Type: typ,
-		}
+		typ.Elem = p.parseTypeReference()
 		p.expect(lexer.BracketR)
 	} else {
-		typ = p.parseNamedType()
+		typ.NamedType = p.parseName()
 	}
 
 	if p.skip(lexer.Bang) {
-		typ = NonNullType{
-			Type: typ,
-		}
+		typ.NonNull = true
 	}
-	return typ
-}
-
-func (p *parser) parseNamedType() NamedType {
-	return NamedType(p.parseName())
+	return &typ
 }
 
 func (p *parser) parseName() string {

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -104,7 +104,7 @@ func (p *parser) parseOperationTypeDefinition() OperationTypeDefinition {
 	var op OperationTypeDefinition
 	op.Operation = p.parseOperationType()
 	p.expect(lexer.Colon)
-	op.Type = p.parseNamedType()
+	op.Type = p.parseName()
 	return op
 }
 
@@ -132,16 +132,16 @@ func (p *parser) parseObjectTypeDefinition(description string) Definition {
 	return def
 }
 
-func (p *parser) parseImplementsInterfaces() []NamedType {
-	var types []NamedType
+func (p *parser) parseImplementsInterfaces() []string {
+	var types []string
 	if p.peek().Value == "implements" {
 		p.next()
 		// optional leading ampersand
 		p.skip(lexer.Amp)
 
-		types = append(types, p.parseNamedType())
+		types = append(types, p.parseName())
 		for p.skip(lexer.Amp) && p.err == nil {
-			types = append(types, p.parseNamedType())
+			types = append(types, p.parseName())
 		}
 	}
 	return types
@@ -213,15 +213,15 @@ func (p *parser) parseUnionTypeDefinition(description string) Definition {
 	return def
 }
 
-func (p *parser) parseUnionMemberTypes() []NamedType {
-	var types []NamedType
+func (p *parser) parseUnionMemberTypes() []string {
+	var types []string
 	if p.skip(lexer.Equals) {
 		// optional leading pipe
 		p.skip(lexer.Pipe)
 
-		types = append(types, p.parseNamedType())
+		types = append(types, p.parseName())
 		for p.skip(lexer.Pipe) && p.err == nil {
-			types = append(types, p.parseNamedType())
+			types = append(types, p.parseName())
 		}
 	}
 	return types

--- a/spec/dumper.go
+++ b/spec/dumper.go
@@ -145,7 +145,7 @@ func isZero(v reflect.Value) bool {
 	case reflect.String:
 		return v.String() == ""
 	}
-	fmt.Println(strconv.Quote(v.String()), strconv.Quote(reflect.Zero(v.Type()).String()))
+
 	// Compare other types directly:
 	return reflect.DeepEqual(v.Interface(), reflect.Zero(v.Type()))
 }

--- a/spec/query.yml
+++ b/spec/query.yml
@@ -174,9 +174,9 @@ ast:
             VariableDefinition: [VariableDefinition]
             - <VariableDefinition>
                 Variable: "v"
-                Type: NamedType("Boolean")
+                Type: Boolean
                 DefaultValue: false
-            TypeCondition: NamedType("t")
+            TypeCondition: "t"
             SelectionSet: [Selection]
             - <Field>
                 Name: "f"
@@ -243,20 +243,16 @@ types:
             VariableDefinitions: [VariableDefinition]
             - <VariableDefinition>
                 Variable: "string"
-                Type: NamedType("String")
+                Type: String
             - <VariableDefinition>
                 Variable: "int"
-                Type: NamedType("Int")
+                Type: Int
             - <VariableDefinition>
                 Variable: "arr"
-                Type: <ListType>
-                  Type: NamedType("Arr")
+                Type: [Arr]
             - <VariableDefinition>
                 Variable: "notnull"
-                Type: <NonNullType>
-                  Type: <ListType>
-                    Type: <NonNullType>
-                      Type: NamedType("Arr")
+                Type: [Arr!]!
             SelectionSet: [Selection]
             - <Field>
                 Name: "f"
@@ -330,10 +326,10 @@ large queries:
             VariableDefinitions: [VariableDefinition]
             - <VariableDefinition>
                 Variable: "foo"
-                Type: NamedType("ComplexType")
+                Type: ComplexType
             - <VariableDefinition>
                 Variable: "site"
-                Type: NamedType("Site")
+                Type: Site
                 DefaultValue: "MOBILE"
             SelectionSet: [Selection]
             - <Field>
@@ -347,7 +343,7 @@ large queries:
                 - <Field>
                     Name: "id"
                 - <InlineFragment>
-                    TypeCondition: NamedType("User")
+                    TypeCondition: "User"
                     Directives: [Directive]
                     - <Directive>
                         Name: "defer"
@@ -419,7 +415,7 @@ large queries:
             VariableDefinitions: [VariableDefinition]
             - <VariableDefinition>
                 Variable: "input"
-                Type: NamedType("StoryLikeSubscribeInput")
+                Type: StoryLikeSubscribeInput
             SelectionSet: [Selection]
             - <Field>
                 Name: "storyLikeSubscribe"
@@ -460,7 +456,7 @@ large queries:
         Fragments: [FragmentDefinition]
         - <FragmentDefinition>
             Name: "frag"
-            TypeCondition: NamedType("Friend")
+            TypeCondition: "Friend"
             SelectionSet: [Selection]
             - <Field>
                 Name: "foo"

--- a/spec/schema.yml
+++ b/spec/schema.yml
@@ -13,7 +13,7 @@ object types:
             Fields: [FieldDefinition]
             - <FieldDefinition>
                 Name: "world"
-                Type: NamedType("String")
+                Type: String
 
   - name: with description
     input: |
@@ -31,7 +31,7 @@ object types:
             Fields: [FieldDefinition]
             - <FieldDefinition>
                 Name: "world"
-                Type: NamedType("String")
+                Type: String
 
   - name: with block description
     input: |
@@ -52,7 +52,7 @@ object types:
             Fields: [FieldDefinition]
             - <FieldDefinition>
                 Name: "world"
-                Type: NamedType("String")
+                Type: String
   - name: with field arg
     input: |
       type Hello {
@@ -70,8 +70,8 @@ object types:
                 Arguments: [FieldDefinition]
                 - <FieldDefinition>
                     Name: "flag"
-                    Type: NamedType("Boolean")
-                Type: NamedType("String")
+                    Type: Boolean
+                Type: String
 
   - name: with field arg and default value
     input: |
@@ -91,8 +91,8 @@ object types:
                 - <FieldDefinition>
                     Name: "flag"
                     DefaultValue: true
-                    Type: NamedType("Boolean")
-                Type: NamedType("String")
+                    Type: Boolean
+                Type: String
 
   - name: with field list arg
     input: |
@@ -111,9 +111,8 @@ object types:
                 Arguments: [FieldDefinition]
                 - <FieldDefinition>
                     Name: "things"
-                    Type: <ListType>
-                      Type: NamedType("String")
-                Type: NamedType("String")
+                    Type: [String]
+                Type: String
 
   - name: with two args
     input: |
@@ -132,11 +131,11 @@ object types:
                 Arguments: [FieldDefinition]
                 - <FieldDefinition>
                     Name: "argOne"
-                    Type: NamedType("Boolean")
+                    Type: Boolean
                 - <FieldDefinition>
                     Name: "argTwo"
-                    Type: NamedType("Int")
-                Type: NamedType("String")
+                    Type: Int
+                Type: String
 
 type extensions:
   - name: Object extension
@@ -153,7 +152,7 @@ type extensions:
             Fields: [FieldDefinition]
             - <FieldDefinition>
                 Name: "world"
-                Type: NamedType("String")
+                Type: String
 
   - name: without any fields
     input: "extend type Hello implements Greeting"
@@ -163,8 +162,8 @@ type extensions:
         - <Definition>
             Kind: DefinitionKind("OBJECT")
             Name: "Hello"
-            Interfaces: [NamedType]
-            - NamedType("Greeting")
+            Interfaces: [string]
+            - "Greeting"
 
   - name: without fields twice
     input: |
@@ -176,13 +175,13 @@ type extensions:
         - <Definition>
             Kind: DefinitionKind("OBJECT")
             Name: "Hello"
-            Interfaces: [NamedType]
-            - NamedType("Greeting")
+            Interfaces: [string]
+            - "Greeting"
         - <Definition>
             Kind: DefinitionKind("OBJECT")
             Name: "Hello"
-            Interfaces: [NamedType]
-            - NamedType("SecondGreeting")
+            Interfaces: [string]
+            - "SecondGreeting"
 
   - name: without anything errors
     input: "extend type Hello"
@@ -222,7 +221,7 @@ schema definition:
             OperationTypes: [OperationTypeDefinition]
             - <OperationTypeDefinition>
                 Operation: Operation("query")
-                Type: NamedType("Query")
+                Type: "Query"
 
 schema extensions:
   - name: simple
@@ -237,7 +236,7 @@ schema extensions:
             OperationTypes: [OperationTypeDefinition]
             - <OperationTypeDefinition>
                 Operation: Operation("mutation")
-                Type: NamedType("Mutation")
+                Type: "Mutation"
 
   - name: directive only
     input: "extend schema @directive"
@@ -314,12 +313,12 @@ inheritance:
         - <Definition>
             Kind: DefinitionKind("OBJECT")
             Name: "Hello"
-            Interfaces: [NamedType]
-            - NamedType("World")
+            Interfaces: [string]
+            - "World"
             Fields: [FieldDefinition]
             - <FieldDefinition>
                 Name: "field"
-                Type: NamedType("String")
+                Type: String
 
   - name: multi
     input: "type Hello implements Wo & rld { field: String }"
@@ -329,13 +328,13 @@ inheritance:
         - <Definition>
             Kind: DefinitionKind("OBJECT")
             Name: "Hello"
-            Interfaces: [NamedType]
-            - NamedType("Wo")
-            - NamedType("rld")
+            Interfaces: [string]
+            - "Wo"
+            - "rld"
             Fields: [FieldDefinition]
             - <FieldDefinition>
                 Name: "field"
-                Type: NamedType("String")
+                Type: String
 
   - name: multi with leading amp
     input: "type Hello implements & Wo & rld { field: String }"
@@ -345,13 +344,13 @@ inheritance:
         - <Definition>
             Kind: DefinitionKind("OBJECT")
             Name: "Hello"
-            Interfaces: [NamedType]
-            - NamedType("Wo")
-            - NamedType("rld")
+            Interfaces: [string]
+            - "Wo"
+            - "rld"
             Fields: [FieldDefinition]
             - <FieldDefinition>
                 Name: "field"
-                Type: NamedType("String")
+                Type: String
 
 enums:
   - name: single value
@@ -395,7 +394,7 @@ interface:
             Fields: [FieldDefinition]
             - <FieldDefinition>
                 Name: "world"
-                Type: NamedType("String")
+                Type: String
 
 unions:
   - name: simple
@@ -406,8 +405,8 @@ unions:
         - <Definition>
             Kind: DefinitionKind("UNION")
             Name: "Hello"
-            Types: [NamedType]
-            - NamedType("World")
+            Types: [string]
+            - "World"
 
   - name: with two types
     input: "union Hello = Wo | Rld"
@@ -417,9 +416,9 @@ unions:
         - <Definition>
             Kind: DefinitionKind("UNION")
             Name: "Hello"
-            Types: [NamedType]
-            - NamedType("Wo")
-            - NamedType("Rld")
+            Types: [string]
+            - "Wo"
+            - "Rld"
 
   - name: with leading pipe
     input: "union Hello = | Wo | Rld"
@@ -429,9 +428,9 @@ unions:
         - <Definition>
             Kind: DefinitionKind("UNION")
             Name: "Hello"
-            Types: [NamedType]
-            - NamedType("Wo")
-            - NamedType("Rld")
+            Types: [string]
+            - "Wo"
+            - "Rld"
 
   - name: cant be empty
     input: "union Hello = || Wo | Rld"
@@ -476,7 +475,7 @@ input object:
             Fields: [FieldDefinition]
             - <FieldDefinition>
                 Name: "world"
-                Type: NamedType("String")
+                Type: String
 
   - name: can not have args
     input: |

--- a/validator/rules/fields_on_correct_type.go
+++ b/validator/rules/fields_on_correct_type.go
@@ -50,12 +50,12 @@ func getSuggestedTypeNames(walker *Walker, parent *ast.Definition, name string) 
 		suggestedObjectTypes = append(suggestedObjectTypes, possibleType.Name)
 
 		for _, possibleInterface := range possibleType.Interfaces {
-			interfaceField := walker.Schema.Types[possibleInterface.Name()]
+			interfaceField := walker.Schema.Types[possibleInterface]
 			if interfaceField != nil && interfaceField.Field(name) != nil {
-				if interfaceUsageCount[possibleInterface.Name()] == 0 {
-					suggestedInterfaceTypes = append(suggestedInterfaceTypes, possibleInterface.Name())
+				if interfaceUsageCount[possibleInterface] == 0 {
+					suggestedInterfaceTypes = append(suggestedInterfaceTypes, possibleInterface)
 				}
-				interfaceUsageCount[possibleInterface.Name()]++
+				interfaceUsageCount[possibleInterface]++
 			}
 		}
 	}

--- a/validator/rules/fragments_on_composite_types.go
+++ b/validator/rules/fragments_on_composite_types.go
@@ -10,22 +10,22 @@ import (
 func init() {
 	AddRule("FragmentsOnCompositeTypes", func(observers *Events, addError AddErrFunc) {
 		observers.OnInlineFragment(func(walker *Walker, inlineFragment *ast.InlineFragment) {
-			fragmentType := walker.Schema.Types[inlineFragment.TypeCondition.Name()]
+			fragmentType := walker.Schema.Types[inlineFragment.TypeCondition]
 			if fragmentType == nil || fragmentType.IsCompositeType() {
 				return
 			}
 
-			message := fmt.Sprintf(`Fragment cannot condition on non composite type "%s".`, inlineFragment.TypeCondition.Name())
+			message := fmt.Sprintf(`Fragment cannot condition on non composite type "%s".`, inlineFragment.TypeCondition)
 
 			addError(Message(message))
 		})
 
 		observers.OnFragment(func(walker *Walker, fragment *ast.FragmentDefinition) {
-			if fragment.Definition == nil || fragment.TypeCondition.Name() == "" || fragment.Definition.IsCompositeType() {
+			if fragment.Definition == nil || fragment.TypeCondition == "" || fragment.Definition.IsCompositeType() {
 				return
 			}
 
-			message := fmt.Sprintf(`Fragment "%s" cannot condition on non composite type "%s".`, fragment.Name, fragment.TypeCondition.Name())
+			message := fmt.Sprintf(`Fragment "%s" cannot condition on non composite type "%s".`, fragment.Name, fragment.TypeCondition)
 
 			addError(Message(message))
 		})

--- a/validator/rules/known_type_names.go
+++ b/validator/rules/known_type_names.go
@@ -22,7 +22,7 @@ func init() {
 		})
 
 		observers.OnInlineFragment(func(walker *Walker, inlineFragment *ast.InlineFragment) {
-			typedName := inlineFragment.TypeCondition.Name()
+			typedName := inlineFragment.TypeCondition
 			if typedName == "" {
 				return
 			}
@@ -38,7 +38,7 @@ func init() {
 		})
 
 		observers.OnFragment(func(walker *Walker, fragment *ast.FragmentDefinition) {
-			typeName := fragment.TypeCondition.Name()
+			typeName := fragment.TypeCondition
 			def := walker.Schema.Types[typeName]
 			if def != nil {
 				return

--- a/validator/rules/possible_fragment_spreads.go
+++ b/validator/rules/possible_fragment_spreads.go
@@ -45,8 +45,8 @@ func init() {
 		}
 
 		observers.OnInlineFragment(func(walker *Walker, inlineFragment *ast.InlineFragment) {
-			validate(walker, inlineFragment.ObjectDefinition, inlineFragment.TypeCondition.Name(), func() {
-				addError(Message(`Fragment cannot be spread here as objects of type "%s" can never be of type "%s".`, inlineFragment.ObjectDefinition.Name, inlineFragment.TypeCondition.Name()))
+			validate(walker, inlineFragment.ObjectDefinition, inlineFragment.TypeCondition, func() {
+				addError(Message(`Fragment cannot be spread here as objects of type "%s" can never be of type "%s".`, inlineFragment.ObjectDefinition.Name, inlineFragment.TypeCondition))
 			})
 		})
 
@@ -54,8 +54,8 @@ func init() {
 			if fragmentSpread.Definition == nil {
 				return
 			}
-			validate(walker, fragmentSpread.ObjectDefinition, fragmentSpread.Definition.TypeCondition.Name(), func() {
-				addError(Message(`Fragment "%s" cannot be spread here as objects of type "%s" can never be of type "%s".`, fragmentSpread.Name, fragmentSpread.ObjectDefinition.Name, fragmentSpread.Definition.TypeCondition.Name()))
+			validate(walker, fragmentSpread.ObjectDefinition, fragmentSpread.Definition.TypeCondition, func() {
+				addError(Message(`Fragment "%s" cannot be spread here as objects of type "%s" can never be of type "%s".`, fragmentSpread.Name, fragmentSpread.ObjectDefinition.Name, fragmentSpread.Definition.TypeCondition))
 			})
 		})
 	})

--- a/validator/rules/provided_required_arguments.go
+++ b/validator/rules/provided_required_arguments.go
@@ -15,7 +15,7 @@ func init() {
 
 		argDef:
 			for _, argDef := range field.Definition.Arguments {
-				if !argDef.Type.IsRequired() {
+				if !argDef.Type.NonNull {
 					continue
 				}
 				if argDef.DefaultValue != nil {
@@ -38,7 +38,7 @@ func init() {
 
 		argDef:
 			for _, argDef := range directive.Definition.Arguments {
-				if !argDef.Type.IsRequired() {
+				if !argDef.Type.NonNull {
 					continue
 				}
 				if argDef.DefaultValue != nil {

--- a/validator/rules/values_of_correct_type.go
+++ b/validator/rules/values_of_correct_type.go
@@ -35,13 +35,12 @@ func init() {
 
 			switch value.Kind {
 			case ast.NullValue:
-				if _, nonNullable := value.ExpectedType.(ast.NonNullType); nonNullable {
+				if value.ExpectedType.NonNull {
 					unexpectedTypeMessage(addError, value.ExpectedType.String(), value.String())
 				}
 
 			case ast.ListValue:
-				_, isList := value.ExpectedType.(ast.ListType)
-				if !isList {
+				if value.ExpectedType.Elem == nil {
 					unexpectedTypeMessage(addError, value.ExpectedType.String(), value.String())
 					return
 				}
@@ -84,7 +83,7 @@ func init() {
 			case ast.ObjectValue:
 
 				for _, field := range value.Definition.Fields {
-					if field.Type.IsRequired() {
+					if field.Type.NonNull {
 						fieldValue := value.FieldByName(field.Name)
 						if fieldValue == nil && field.DefaultValue == nil {
 							addError(

--- a/validator/rules/variables_in_allowed_position.go
+++ b/validator/rules/variables_in_allowed_position.go
@@ -15,9 +15,8 @@ func init() {
 			// todo: move me into walk
 			// If there is a default non nullable types can be null
 			if value.VariableDefinition.DefaultValue != nil && value.VariableDefinition.DefaultValue.Kind != ast.NullValue {
-				notNull, isNotNull := value.ExpectedType.(ast.NonNullType)
-				if isNotNull {
-					value.ExpectedType = notNull.Type
+				if value.ExpectedType.NonNull {
+					value.ExpectedType.NonNull = false
 				}
 			}
 

--- a/validator/walk.go
+++ b/validator/walk.go
@@ -117,7 +117,7 @@ func (w *Walker) walkOperation(operation *ast.OperationDefinition) {
 }
 
 func (w *Walker) walkFragment(it *ast.FragmentDefinition) {
-	def := w.Schema.Types[it.TypeCondition.Name()]
+	def := w.Schema.Types[it.TypeCondition]
 
 	it.Definition = def
 
@@ -184,8 +184,8 @@ func (w *Walker) walkValue(value *ast.Value) {
 
 	if value.Kind == ast.ListValue {
 		for _, child := range value.Children {
-			if listType, isList := value.ExpectedType.(ast.ListType); isList {
-				child.Value.ExpectedType = listType.Type
+			if value.ExpectedType.Elem != nil {
+				child.Value.ExpectedType = value.ExpectedType.Elem
 				child.Value.Definition = value.Definition
 			}
 
@@ -211,7 +211,7 @@ func (w *Walker) walkSelection(parentDef *ast.Definition, it ast.Selection) {
 		if it.Name == "__typename" {
 			def = &ast.FieldDefinition{
 				Name: "__typename",
-				Type: ast.NamedType("String"),
+				Type: ast.NamedType("string"),
 			}
 		} else if parentDef != nil {
 			def = parentDef.Field(it.Name)
@@ -251,8 +251,8 @@ func (w *Walker) walkSelection(parentDef *ast.Definition, it ast.Selection) {
 		}
 
 		var nextParentDef *ast.Definition
-		if it.TypeCondition.Name() != "" {
-			nextParentDef = w.Schema.Types[it.TypeCondition.Name()]
+		if it.TypeCondition != "" {
+			nextParentDef = w.Schema.Types[it.TypeCondition]
 		}
 
 		w.walkDirectives(nextParentDef, it.Directives, ast.LocationInlineFragment)
@@ -272,7 +272,7 @@ func (w *Walker) walkSelection(parentDef *ast.Definition, it ast.Selection) {
 
 		var nextParentDef *ast.Definition
 		if def != nil {
-			nextParentDef = w.Schema.Types[def.TypeCondition.Name()]
+			nextParentDef = w.Schema.Types[def.TypeCondition]
 		}
 
 		w.walkDirectives(nextParentDef, it.Directives, ast.LocationFragmentSpread)


### PR DESCRIPTION
flatten out a few rough edges with type:
 - NonNull always applies to the next element and can be on either list or named type, lets just make it a prop rather than deal with it everywhere.
 - use a one hot struct instead of type casting between the two remaining types everywhere (List and Named)
 - stop wrapping named type references, avoiding a whole bunch of unnecessary type juggling.