### PR TITLE
Make collections more consistent

### DIFF
--- a/ast/collections.go
+++ b/ast/collections.go
@@ -1,0 +1,124 @@
+package ast
+
+type FieldList []*FieldDefinition
+
+func (l FieldList) ForName(name string) *FieldDefinition {
+	for _, it := range l {
+		if it.Name == name {
+			return it
+		}
+	}
+	return nil
+}
+
+type EnumValueList []*EnumValueDefinition
+
+func (l EnumValueList) ForName(name string) *EnumValueDefinition {
+	for _, it := range l {
+		if it.Name == name {
+			return it
+		}
+	}
+	return nil
+}
+
+type DirectiveList []*Directive
+
+func (l DirectiveList) ForName(name string) *Directive {
+	for _, it := range l {
+		if it.Name == name {
+			return it
+		}
+	}
+	return nil
+}
+
+type OperationList []*OperationDefinition
+
+func (l OperationList) ForName(name string) *OperationDefinition {
+	for _, it := range l {
+		if it.Name == name {
+			return it
+		}
+	}
+	return nil
+}
+
+type FragmentDefinitionList []*FragmentDefinition
+
+func (l FragmentDefinitionList) ForName(name string) *FragmentDefinition {
+	for _, it := range l {
+		if it.Name == name {
+			return it
+		}
+	}
+	return nil
+}
+
+type VariableDefinitionList []*VariableDefinition
+
+func (l VariableDefinitionList) ForName(name string) *VariableDefinition {
+	for _, it := range l {
+		if it.Variable == name {
+			return it
+		}
+	}
+	return nil
+}
+
+type ArgumentList []*Argument
+
+func (l ArgumentList) ForName(name string) *Argument {
+	for _, it := range l {
+		if it.Name == name {
+			return it
+		}
+	}
+	return nil
+}
+
+type SchemaDefinitionList []*SchemaDefinition
+
+type DirectiveDefinitionList []*DirectiveDefinition
+
+func (l DirectiveDefinitionList) ForName(name string) *DirectiveDefinition {
+	for _, it := range l {
+		if it.Name == name {
+			return it
+		}
+	}
+	return nil
+}
+
+type DefinitionList []*Definition
+
+func (l DefinitionList) ForName(name string) *Definition {
+	for _, it := range l {
+		if it.Name == name {
+			return it
+		}
+	}
+	return nil
+}
+
+type OperationTypeDefinitionList []*OperationTypeDefinition
+
+func (l OperationTypeDefinitionList) ForType(name string) *OperationTypeDefinition {
+	for _, it := range l {
+		if it.Type == name {
+			return it
+		}
+	}
+	return nil
+}
+
+type ChildValueList []*ChildValue
+
+func (v ChildValueList) ForName(name string) *Value {
+	for _, f := range v {
+		if f.Name == name {
+			return f.Value
+		}
+	}
+	return nil
+}

--- a/ast/definition.go
+++ b/ast/definition.go
@@ -23,29 +23,11 @@ type Definition struct {
 	Kind        DefinitionKind
 	Description string
 	Name        string
-	Directives  Directives
-	Interfaces  []string              // object and input object
-	Fields      FieldList             // object and input object
-	Types       []string              // union
-	Values      []EnumValueDefinition // enum
-}
-
-func (d *Definition) Field(name string) *FieldDefinition {
-	for _, f := range d.Fields {
-		if f.Name == name {
-			return f
-		}
-	}
-	return nil
-}
-
-func (d *Definition) EnumValue(name string) *EnumValueDefinition {
-	for _, e := range d.Values {
-		if e.Name == name {
-			return &e
-		}
-	}
-	return nil
+	Directives  DirectiveList
+	Interfaces  []string      // object and input object
+	Fields      FieldList     // object and input object
+	Types       []string      // union
+	EnumValues  EnumValueList // enum
 }
 
 func (d *Definition) IsLeafType() bool {
@@ -79,24 +61,13 @@ type FieldDefinition struct {
 	Arguments    FieldList // only for objects
 	DefaultValue *Value    // only for input objects
 	Type         *Type
-	Directives   Directives
-}
-
-type FieldList []*FieldDefinition
-
-func (f FieldList) ForName(name string) *FieldDefinition {
-	for _, field := range f {
-		if field.Name == name {
-			return field
-		}
-	}
-	return nil
+	Directives   DirectiveList
 }
 
 type EnumValueDefinition struct {
 	Description string
 	Name        string
-	Directives  Directives
+	Directives  DirectiveList
 }
 
 // Directive Definitions

--- a/ast/directive.go
+++ b/ast/directive.go
@@ -28,30 +28,10 @@ const (
 
 type Directive struct {
 	Name      string
-	Arguments []Argument
+	Arguments ArgumentList
 
 	// Requires validation
 	ParentDefinition *Definition
 	Definition       *DirectiveDefinition
 	Location         DirectiveLocation
-}
-
-type Directives []*Directive
-
-func (d Directives) Get(name string) *Directive {
-	for _, directive := range d {
-		if directive.Name == name {
-			return directive
-		}
-	}
-	return nil
-}
-
-func (d Directive) GetArg(name string) *Argument {
-	for i := range d.Arguments {
-		if d.Arguments[i].Name == name {
-			return &d.Arguments[i]
-		}
-	}
-	return nil
 }

--- a/ast/document.go
+++ b/ast/document.go
@@ -1,40 +1,22 @@
 package ast
 
 type QueryDocument struct {
-	Operations []OperationDefinition
-	Fragments  []FragmentDefinition
-}
-
-func (d QueryDocument) GetOperation(name string) *OperationDefinition {
-	for _, o := range d.Operations {
-		if o.Name == name {
-			return &o
-		}
-	}
-	return nil
-}
-
-func (d QueryDocument) GetFragment(name string) *FragmentDefinition {
-	for _, f := range d.Fragments {
-		if f.Name == name {
-			return &f
-		}
-	}
-	return nil
+	Operations OperationList
+	Fragments  FragmentDefinitionList
 }
 
 type SchemaDocument struct {
-	Schema          []SchemaDefinition
-	SchemaExtension []SchemaDefinition
-	Directives      []DirectiveDefinition
-	Definitions     []Definition
-	Extensions      []Definition
+	Schema          SchemaDefinitionList
+	SchemaExtension SchemaDefinitionList
+	Directives      DirectiveDefinitionList
+	Definitions     DefinitionList
+	Extensions      DefinitionList
 }
 
 type SchemaDefinition struct {
 	Description    string
-	Directives     []*Directive
-	OperationTypes []OperationTypeDefinition
+	Directives     DirectiveList
+	OperationTypes OperationTypeDefinitionList
 }
 
 type OperationTypeDefinition struct {

--- a/ast/document_test.go
+++ b/ast/document_test.go
@@ -20,13 +20,13 @@ func TestQueryDocMethods(t *testing.T) {
 
 	require.Nil(t, err)
 	t.Run("GetOperation", func(t *testing.T) {
-		require.EqualValues(t, "Bob", doc.GetOperation("Bob").Name)
-		require.Nil(t, doc.GetOperation("Alice"))
+		require.EqualValues(t, "Bob", doc.Operations.ForName("Bob").Name)
+		require.Nil(t, doc.Operations.ForName("Alice"))
 	})
 
 	t.Run("GetFragment", func(t *testing.T) {
-		require.EqualValues(t, "Frag", doc.GetFragment("Frag").Name)
-		require.Nil(t, doc.GetOperation("Alice"))
+		require.EqualValues(t, "Frag", doc.Fragments.ForName("Frag").Name)
+		require.Nil(t, doc.Fragments.ForName("Alice"))
 	})
 }
 

--- a/ast/fragment.go
+++ b/ast/fragment.go
@@ -2,7 +2,7 @@ package ast
 
 type FragmentSpread struct {
 	Name       string
-	Directives []*Directive
+	Directives DirectiveList
 
 	// Require validation
 	ObjectDefinition *Definition
@@ -11,7 +11,7 @@ type FragmentSpread struct {
 
 type InlineFragment struct {
 	TypeCondition string
-	Directives    []*Directive
+	Directives    DirectiveList
 	SelectionSet  SelectionSet
 
 	// Require validation
@@ -22,9 +22,9 @@ type FragmentDefinition struct {
 	Name string
 	// Note: fragment variable definitions are experimental and may be changed
 	// or removed in the future.
-	VariableDefinition VariableDefinitions
+	VariableDefinition VariableDefinitionList
 	TypeCondition      string
-	Directives         []*Directive
+	Directives         DirectiveList
 	SelectionSet       SelectionSet
 
 	// Require validation

--- a/ast/operation.go
+++ b/ast/operation.go
@@ -11,21 +11,9 @@ const (
 type OperationDefinition struct {
 	Operation           Operation
 	Name                string
-	VariableDefinitions VariableDefinitions
-	Directives          []*Directive
+	VariableDefinitions VariableDefinitionList
+	Directives          DirectiveList
 	SelectionSet        SelectionSet
-}
-
-type VariableDefinitions []*VariableDefinition
-
-func (v VariableDefinitions) Find(name string) *VariableDefinition {
-	for i := range v {
-		def := v[i]
-		if def.Variable == name {
-			return def
-		}
-	}
-	return nil
 }
 
 type VariableDefinition struct {

--- a/ast/selection.go
+++ b/ast/selection.go
@@ -6,15 +6,15 @@ type Selection interface {
 	isSelection()
 }
 
-func (Field) isSelection()          {}
-func (FragmentSpread) isSelection() {}
-func (InlineFragment) isSelection() {}
+func (*Field) isSelection()          {}
+func (*FragmentSpread) isSelection() {}
+func (*InlineFragment) isSelection() {}
 
 type Field struct {
 	Alias        string
 	Name         string
-	Arguments    []Argument
-	Directives   []*Directive
+	Arguments    ArgumentList
+	Directives   DirectiveList
 	SelectionSet SelectionSet
 
 	// Require validation

--- a/ast/value.go
+++ b/ast/value.go
@@ -23,10 +23,10 @@ const (
 
 type Value struct {
 	Raw      string
-	Children []ChildValue
+	Children ChildValueList
 	Kind     ValueKind
 
-	// Require validation
+	// Require validation a mouse from the cupboard
 	Definition         *Definition
 	VariableDefinition *VariableDefinition
 	ExpectedType       *Type
@@ -35,22 +35,6 @@ type Value struct {
 type ChildValue struct {
 	Name  string
 	Value *Value
-}
-
-func (v *Value) FieldByName(name string) *Value {
-	for _, f := range v.Children {
-		if f.Name == name {
-			return f.Value
-		}
-	}
-	return nil
-}
-
-func (v *Value) Field(i int) *Value {
-	if len(v.Children) <= i {
-		return nil
-	}
-	return v.Children[i].Value
 }
 
 func (v *Value) Value(vars map[string]interface{}) (interface{}, error) {

--- a/parser/loader.go
+++ b/parser/loader.go
@@ -73,13 +73,13 @@ func LoadSchema(input string) (*Schema, error) {
 		if schema.Types[def.Name] != nil {
 			return nil, fmt.Errorf("Cannot redeclare type %s.", def.Name)
 		}
-		schema.Types[def.Name] = &ast.Definitions[i]
+		schema.Types[def.Name] = ast.Definitions[i]
 
 		if def.Kind != Interface {
 			for _, intf := range def.Interfaces {
-				schema.AddPossibleType(intf, &ast.Definitions[i])
+				schema.AddPossibleType(intf, ast.Definitions[i])
 			}
-			schema.AddPossibleType(def.Name, &ast.Definitions[i])
+			schema.AddPossibleType(def.Name, ast.Definitions[i])
 		}
 	}
 
@@ -97,14 +97,14 @@ func LoadSchema(input string) (*Schema, error) {
 		def.Interfaces = append(def.Interfaces, ext.Interfaces...)
 		def.Fields = append(def.Fields, ext.Fields...)
 		def.Types = append(def.Types, ext.Types...)
-		def.Values = append(def.Values, ext.Values...)
+		def.EnumValues = append(def.EnumValues, ext.EnumValues...)
 	}
 
 	for i, dir := range ast.Directives {
 		if schema.Directives[dir.Name] != nil {
 			return nil, fmt.Errorf("Cannot redeclare directive %s.", dir.Name)
 		}
-		schema.Directives[dir.Name] = &ast.Directives[i]
+		schema.Directives[dir.Name] = ast.Directives[i]
 	}
 
 	if len(ast.Schema) > 1 {

--- a/parser/query.go
+++ b/parser/query.go
@@ -40,9 +40,9 @@ func (p *parser) parseQueryDocument() *QueryDocument {
 	return &doc
 }
 
-func (p *parser) parseOperationDefinition() OperationDefinition {
+func (p *parser) parseOperationDefinition() *OperationDefinition {
 	if p.peek().Kind == lexer.BraceL {
-		return OperationDefinition{
+		return &OperationDefinition{
 			SelectionSet: p.parseSelectionSet(),
 		}
 	}
@@ -59,7 +59,7 @@ func (p *parser) parseOperationDefinition() OperationDefinition {
 	od.Directives = p.parseDirectives(false)
 	od.SelectionSet = p.parseSelectionSet()
 
-	return od
+	return &od
 }
 
 func (p *parser) parseOperationType() Operation {
@@ -76,7 +76,7 @@ func (p *parser) parseOperationType() Operation {
 	return ""
 }
 
-func (p *parser) parseVariableDefinitions() VariableDefinitions {
+func (p *parser) parseVariableDefinitions() VariableDefinitionList {
 	var defs []*VariableDefinition
 	p.many(lexer.ParenL, lexer.ParenR, func() {
 		defs = append(defs, p.parseVariableDefinition())
@@ -122,7 +122,7 @@ func (p *parser) parseSelection() Selection {
 	return p.parseField()
 }
 
-func (p *parser) parseField() Field {
+func (p *parser) parseField() *Field {
 	var field Field
 
 	field.Alias = p.parseName()
@@ -139,11 +139,11 @@ func (p *parser) parseField() Field {
 		field.SelectionSet = p.parseSelectionSet()
 	}
 
-	return field
+	return &field
 }
 
-func (p *parser) parseArguments(isConst bool) []Argument {
-	var arguments []Argument
+func (p *parser) parseArguments(isConst bool) ArgumentList {
+	var arguments ArgumentList
 	p.many(lexer.ParenL, lexer.ParenR, func() {
 		arguments = append(arguments, p.parseArgument(isConst))
 	})
@@ -151,21 +151,21 @@ func (p *parser) parseArguments(isConst bool) []Argument {
 	return arguments
 }
 
-func (p *parser) parseArgument(isConst bool) Argument {
+func (p *parser) parseArgument(isConst bool) *Argument {
 	arg := Argument{}
 
 	arg.Name = p.parseName()
 	p.expect(lexer.Colon)
 
 	arg.Value = p.parseValueLiteral(isConst)
-	return arg
+	return &arg
 }
 
 func (p *parser) parseFragment() Selection {
 	p.expect(lexer.Spread)
 
 	if peek := p.peek(); peek.Kind == lexer.Name && peek.Value != "on" {
-		return FragmentSpread{
+		return &FragmentSpread{
 			Name:       p.parseFragmentName(),
 			Directives: p.parseDirectives(false),
 		}
@@ -180,10 +180,10 @@ func (p *parser) parseFragment() Selection {
 
 	def.Directives = p.parseDirectives(false)
 	def.SelectionSet = p.parseSelectionSet()
-	return def
+	return &def
 }
 
-func (p *parser) parseFragmentDefinition() FragmentDefinition {
+func (p *parser) parseFragmentDefinition() *FragmentDefinition {
 	var def FragmentDefinition
 	p.expectKeyword("fragment")
 
@@ -195,7 +195,7 @@ func (p *parser) parseFragmentDefinition() FragmentDefinition {
 	def.TypeCondition = p.parseName()
 	def.Directives = p.parseDirectives(false)
 	def.SelectionSet = p.parseSelectionSet()
-	return def
+	return &def
 }
 
 func (p *parser) parseFragmentName() string {
@@ -250,16 +250,16 @@ func (p *parser) parseValueLiteral(isConst bool) *Value {
 }
 
 func (p *parser) parseList(isConst bool) *Value {
-	var values []ChildValue
+	var values ChildValueList
 	p.many(lexer.BracketL, lexer.BracketR, func() {
-		values = append(values, ChildValue{Value: p.parseValueLiteral(isConst)})
+		values = append(values, &ChildValue{Value: p.parseValueLiteral(isConst)})
 	})
 
 	return &Value{Children: values, Kind: ListValue}
 }
 
 func (p *parser) parseObject(isConst bool) *Value {
-	var fields []ChildValue
+	var fields ChildValueList
 	p.many(lexer.BraceL, lexer.BraceR, func() {
 		fields = append(fields, p.parseObjectField(isConst))
 	})
@@ -267,14 +267,14 @@ func (p *parser) parseObject(isConst bool) *Value {
 	return &Value{Children: fields, Kind: ObjectValue}
 }
 
-func (p *parser) parseObjectField(isConst bool) ChildValue {
+func (p *parser) parseObjectField(isConst bool) *ChildValue {
 	field := ChildValue{}
 	field.Name = p.parseName()
 
 	p.expect(lexer.Colon)
 
 	field.Value = p.parseValueLiteral(isConst)
-	return field
+	return &field
 }
 
 func (p *parser) parseDirectives(isConst bool) []*Directive {

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -61,11 +61,11 @@ func (p *parser) parseDescription() string {
 	return p.next().Value
 }
 
-func (p *parser) parseTypeSystemDefinition(description string) Definition {
+func (p *parser) parseTypeSystemDefinition(description string) *Definition {
 	tok := p.peek()
 	if tok.Kind != lexer.Name {
 		p.unexpectedError()
-		return Definition{}
+		return nil
 	}
 
 	switch tok.Value {
@@ -83,11 +83,11 @@ func (p *parser) parseTypeSystemDefinition(description string) Definition {
 		return p.parseInputObjectTypeDefinition(description)
 	default:
 		p.unexpectedError()
-		return Definition{}
+		return nil
 	}
 }
 
-func (p *parser) parseSchemaDefinition(description string) SchemaDefinition {
+func (p *parser) parseSchemaDefinition(description string) *SchemaDefinition {
 	p.expectKeyword("schema")
 
 	def := SchemaDefinition{Description: description}
@@ -97,18 +97,18 @@ func (p *parser) parseSchemaDefinition(description string) SchemaDefinition {
 	p.many(lexer.BraceL, lexer.BraceR, func() {
 		def.OperationTypes = append(def.OperationTypes, p.parseOperationTypeDefinition())
 	})
-	return def
+	return &def
 }
 
-func (p *parser) parseOperationTypeDefinition() OperationTypeDefinition {
+func (p *parser) parseOperationTypeDefinition() *OperationTypeDefinition {
 	var op OperationTypeDefinition
 	op.Operation = p.parseOperationType()
 	p.expect(lexer.Colon)
 	op.Type = p.parseName()
-	return op
+	return &op
 }
 
-func (p *parser) parseScalarTypeDefinition(description string) Definition {
+func (p *parser) parseScalarTypeDefinition(description string) *Definition {
 	p.expectKeyword("scalar")
 
 	var def Definition
@@ -116,10 +116,10 @@ func (p *parser) parseScalarTypeDefinition(description string) Definition {
 	def.Description = description
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
-	return def
+	return &def
 }
 
-func (p *parser) parseObjectTypeDefinition(description string) Definition {
+func (p *parser) parseObjectTypeDefinition(description string) *Definition {
 	p.expectKeyword("type")
 
 	var def Definition
@@ -129,7 +129,7 @@ func (p *parser) parseObjectTypeDefinition(description string) Definition {
 	def.Interfaces = p.parseImplementsInterfaces()
 	def.Directives = p.parseDirectives(true)
 	def.Fields = p.parseFieldsDefinition()
-	return def
+	return &def
 }
 
 func (p *parser) parseImplementsInterfaces() []string {
@@ -189,7 +189,7 @@ func (p *parser) parseInputValueDef() *FieldDefinition {
 	return &def
 }
 
-func (p *parser) parseInterfaceTypeDefinition(description string) Definition {
+func (p *parser) parseInterfaceTypeDefinition(description string) *Definition {
 	p.expectKeyword("interface")
 
 	var def Definition
@@ -198,10 +198,10 @@ func (p *parser) parseInterfaceTypeDefinition(description string) Definition {
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
 	def.Fields = p.parseFieldsDefinition()
-	return def
+	return &def
 }
 
-func (p *parser) parseUnionTypeDefinition(description string) Definition {
+func (p *parser) parseUnionTypeDefinition(description string) *Definition {
 	p.expectKeyword("union")
 
 	var def Definition
@@ -210,7 +210,7 @@ func (p *parser) parseUnionTypeDefinition(description string) Definition {
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
 	def.Types = p.parseUnionMemberTypes()
-	return def
+	return &def
 }
 
 func (p *parser) parseUnionMemberTypes() []string {
@@ -227,7 +227,7 @@ func (p *parser) parseUnionMemberTypes() []string {
 	return types
 }
 
-func (p *parser) parseEnumTypeDefinition(description string) Definition {
+func (p *parser) parseEnumTypeDefinition(description string) *Definition {
 	p.expectKeyword("enum")
 
 	var def Definition
@@ -235,27 +235,27 @@ func (p *parser) parseEnumTypeDefinition(description string) Definition {
 	def.Description = description
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
-	def.Values = p.parseEnumValuesDefinition()
-	return def
+	def.EnumValues = p.parseEnumValuesDefinition()
+	return &def
 }
 
-func (p *parser) parseEnumValuesDefinition() []EnumValueDefinition {
-	var values []EnumValueDefinition
+func (p *parser) parseEnumValuesDefinition() EnumValueList {
+	var values EnumValueList
 	p.many(lexer.BraceL, lexer.BraceR, func() {
 		values = append(values, p.parseEnumValueDefinition())
 	})
 	return values
 }
 
-func (p *parser) parseEnumValueDefinition() EnumValueDefinition {
-	return EnumValueDefinition{
+func (p *parser) parseEnumValueDefinition() *EnumValueDefinition {
+	return &EnumValueDefinition{
 		Description: p.parseDescription(),
 		Name:        p.parseName(),
 		Directives:  p.parseDirectives(true),
 	}
 }
 
-func (p *parser) parseInputObjectTypeDefinition(description string) Definition {
+func (p *parser) parseInputObjectTypeDefinition(description string) *Definition {
 	p.expectKeyword("input")
 
 	var def Definition
@@ -264,7 +264,7 @@ func (p *parser) parseInputObjectTypeDefinition(description string) Definition {
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
 	def.Fields = p.parseInputFieldsDefinition()
-	return def
+	return &def
 }
 
 func (p *parser) parseInputFieldsDefinition() FieldList {
@@ -298,7 +298,7 @@ func (p *parser) parseTypeSystemExtension(doc *SchemaDocument) {
 	}
 }
 
-func (p *parser) parseSchemaExtension() SchemaDefinition {
+func (p *parser) parseSchemaExtension() *SchemaDefinition {
 	p.expectKeyword("schema")
 
 	var def SchemaDefinition
@@ -309,10 +309,10 @@ func (p *parser) parseSchemaExtension() SchemaDefinition {
 	if len(def.Directives) == 0 && len(def.OperationTypes) == 0 {
 		p.unexpectedError()
 	}
-	return def
+	return &def
 }
 
-func (p *parser) parseScalarTypeExtension() Definition {
+func (p *parser) parseScalarTypeExtension() *Definition {
 	p.expectKeyword("scalar")
 
 	var def Definition
@@ -322,10 +322,10 @@ func (p *parser) parseScalarTypeExtension() Definition {
 	if len(def.Directives) == 0 {
 		p.unexpectedError()
 	}
-	return def
+	return &def
 }
 
-func (p *parser) parseObjectTypeExtension() Definition {
+func (p *parser) parseObjectTypeExtension() *Definition {
 	p.expectKeyword("type")
 
 	var def Definition
@@ -337,10 +337,10 @@ func (p *parser) parseObjectTypeExtension() Definition {
 	if len(def.Interfaces) == 0 && len(def.Directives) == 0 && len(def.Fields) == 0 {
 		p.unexpectedError()
 	}
-	return def
+	return &def
 }
 
-func (p *parser) parseInterfaceTypeExtension() Definition {
+func (p *parser) parseInterfaceTypeExtension() *Definition {
 	p.expectKeyword("interface")
 
 	var def Definition
@@ -351,10 +351,10 @@ func (p *parser) parseInterfaceTypeExtension() Definition {
 	if len(def.Directives) == 0 && len(def.Fields) == 0 {
 		p.unexpectedError()
 	}
-	return def
+	return &def
 }
 
-func (p *parser) parseUnionTypeExtension() Definition {
+func (p *parser) parseUnionTypeExtension() *Definition {
 	p.expectKeyword("union")
 
 	var def Definition
@@ -366,24 +366,24 @@ func (p *parser) parseUnionTypeExtension() Definition {
 	if len(def.Directives) == 0 && len(def.Types) == 0 {
 		p.unexpectedError()
 	}
-	return def
+	return &def
 }
 
-func (p *parser) parseEnumTypeExtension() Definition {
+func (p *parser) parseEnumTypeExtension() *Definition {
 	p.expectKeyword("enum")
 
 	var def Definition
 	def.Kind = Enum
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
-	def.Values = p.parseEnumValuesDefinition()
-	if len(def.Directives) == 0 && len(def.Values) == 0 {
+	def.EnumValues = p.parseEnumValuesDefinition()
+	if len(def.Directives) == 0 && len(def.EnumValues) == 0 {
 		p.unexpectedError()
 	}
-	return def
+	return &def
 }
 
-func (p *parser) parseInputObjectTypeExtension() Definition {
+func (p *parser) parseInputObjectTypeExtension() *Definition {
 	p.expectKeyword("input")
 
 	var def Definition
@@ -394,10 +394,10 @@ func (p *parser) parseInputObjectTypeExtension() Definition {
 	if len(def.Directives) == 0 && len(def.Fields) == 0 {
 		p.unexpectedError()
 	}
-	return def
+	return &def
 }
 
-func (p *parser) parseDirectiveDefinition(description string) DirectiveDefinition {
+func (p *parser) parseDirectiveDefinition(description string) *DirectiveDefinition {
 	p.expectKeyword("directive")
 	p.expect(lexer.At)
 
@@ -408,7 +408,7 @@ func (p *parser) parseDirectiveDefinition(description string) DirectiveDefinitio
 
 	p.expectKeyword("on")
 	def.Locations = p.parseDirectiveLocations()
-	return def
+	return &def
 }
 
 func (p *parser) parseDirectiveLocations() []DirectiveLocation {

--- a/spec/dumper_test.go
+++ b/spec/dumper_test.go
@@ -14,9 +14,9 @@ func TestDump(t *testing.T) {
 		Directives: []*ast.Directive{
 			{
 				Name:      "foo",
-				Arguments: []ast.Argument{{Name: "bar"}},
+				Arguments: []*ast.Argument{{Name: "bar"}},
 			},
-			{Arguments: []ast.Argument{}},
+			{Arguments: []*ast.Argument{}},
 		},
 	})
 

--- a/spec/schema.yml
+++ b/spec/schema.yml
@@ -361,7 +361,7 @@ enums:
         - <Definition>
             Kind: DefinitionKind("ENUM")
             Name: "Hello"
-            Values: [EnumValueDefinition]
+            EnumValues: [EnumValueDefinition]
             - <EnumValueDefinition>
                 Name: "WORLD"
 
@@ -373,7 +373,7 @@ enums:
         - <Definition>
             Kind: DefinitionKind("ENUM")
             Name: "Hello"
-            Values: [EnumValueDefinition]
+            EnumValues: [EnumValueDefinition]
             - <EnumValueDefinition>
                 Name: "WO"
             - <EnumValueDefinition>

--- a/validator/rules/fields_on_correct_type.go
+++ b/validator/rules/fields_on_correct_type.go
@@ -42,7 +42,7 @@ func getSuggestedTypeNames(walker *Walker, parent *ast.Definition, name string) 
 	interfaceUsageCount := map[string]int{}
 
 	for _, possibleType := range walker.Schema.GetPossibleTypes(parent) {
-		field := possibleType.Field(name)
+		field := possibleType.Fields.ForName(name)
 		if field == nil {
 			continue
 		}
@@ -51,7 +51,7 @@ func getSuggestedTypeNames(walker *Walker, parent *ast.Definition, name string) 
 
 		for _, possibleInterface := range possibleType.Interfaces {
 			interfaceField := walker.Schema.Types[possibleInterface]
-			if interfaceField != nil && interfaceField.Field(name) != nil {
+			if interfaceField != nil && interfaceField.Fields.ForName(name) != nil {
 				if interfaceUsageCount[possibleInterface] == 0 {
 					suggestedInterfaceTypes = append(suggestedInterfaceTypes, possibleInterface)
 				}

--- a/validator/rules/no_fragment_cycles.go
+++ b/validator/rules/no_fragment_cycles.go
@@ -13,7 +13,7 @@ func init() {
 		visitedFrags := make(map[string]bool)
 
 		observers.OnFragment(func(walker *Walker, fragment *ast.FragmentDefinition) {
-			var spreadPath []ast.FragmentSpread
+			var spreadPath []*ast.FragmentSpread
 			spreadPathIndexByName := make(map[string]int)
 
 			var recursive func(fragment *ast.FragmentDefinition)
@@ -37,7 +37,7 @@ func init() {
 
 					spreadPath = append(spreadPath, spreadNode)
 					if !ok {
-						spreadFragment := walker.Document.GetFragment(spreadName)
+						spreadFragment := walker.Document.Fragments.ForName(spreadName)
 						if spreadFragment != nil {
 							recursive(spreadFragment)
 						}
@@ -65,8 +65,8 @@ func init() {
 	})
 }
 
-func getFragmentSpreads(node ast.SelectionSet) []ast.FragmentSpread {
-	var spreads []ast.FragmentSpread
+func getFragmentSpreads(node ast.SelectionSet) []*ast.FragmentSpread {
+	var spreads []*ast.FragmentSpread
 
 	setsToVisit := []ast.SelectionSet{node}
 
@@ -76,11 +76,11 @@ func getFragmentSpreads(node ast.SelectionSet) []ast.FragmentSpread {
 
 		for _, selection := range set {
 			switch selection := selection.(type) {
-			case ast.FragmentSpread:
+			case *ast.FragmentSpread:
 				spreads = append(spreads, selection)
-			case ast.Field:
+			case *ast.Field:
 				setsToVisit = append(setsToVisit, selection.SelectionSet)
-			case ast.InlineFragment:
+			case *ast.InlineFragment:
 				setsToVisit = append(setsToVisit, selection.SelectionSet)
 			}
 		}

--- a/validator/rules/unique_argument_names.go
+++ b/validator/rules/unique_argument_names.go
@@ -17,7 +17,7 @@ func init() {
 	})
 }
 
-func checkUniqueArgs(args []ast.Argument, addError AddErrFunc) {
+func checkUniqueArgs(args ast.ArgumentList, addError AddErrFunc) {
 	knownArgNames := map[string]bool{}
 
 	for _, arg := range args {

--- a/validator/rules/values_of_correct_type.go
+++ b/validator/rules/values_of_correct_type.go
@@ -23,7 +23,7 @@ func init() {
 
 			var possibleEnums []string
 			if value.Definition.Kind == ast.Enum {
-				for _, val := range value.Definition.Values {
+				for _, val := range value.Definition.EnumValues {
 					possibleEnums = append(possibleEnums, val.Name)
 				}
 			}
@@ -67,7 +67,7 @@ func init() {
 				}
 
 			case ast.EnumValue:
-				if value.Definition.Kind != ast.Enum || value.Definition.EnumValue(value.Raw) == nil {
+				if value.Definition.Kind != ast.Enum || value.Definition.EnumValues.ForName(value.Raw) == nil {
 					rawValStr := fmt.Sprint(rawVal)
 					addError(
 						Message("Expected type %s, found %s.", value.ExpectedType.String(), value.String()),
@@ -84,7 +84,7 @@ func init() {
 
 				for _, field := range value.Definition.Fields {
 					if field.Type.NonNull {
-						fieldValue := value.FieldByName(field.Name)
+						fieldValue := value.Children.ForName(field.Name)
 						if fieldValue == nil && field.DefaultValue == nil {
 							addError(
 								Message("Field %s.%s of required type %s was not provided.", value.Definition.Name, field.Name, field.Type.String()),
@@ -95,7 +95,7 @@ func init() {
 				}
 
 				for _, fieldValue := range value.Children {
-					if value.Definition.Field(fieldValue.Name) == nil {
+					if value.Definition.Fields.ForName(fieldValue.Name) == nil {
 						var suggestions []string
 						for _, fieldValue := range value.Definition.Fields {
 							suggestions = append(suggestions, fieldValue.Name)


### PR DESCRIPTION
Consistently use collection wrappers that have a `ForName` method, and make all collections []*thing.