### PR TITLE
Validation positions

### DIFF
--- a/ast/definition.go
+++ b/ast/definition.go
@@ -74,8 +74,6 @@ type EnumValueDefinition struct {
 	Position    *Position `dump:"-"`
 }
 
-// Directive Definitions
-
 type DirectiveDefinition struct {
 	Description string
 	Name        string

--- a/ast/definition.go
+++ b/ast/definition.go
@@ -28,6 +28,8 @@ type Definition struct {
 	Fields      FieldList     // object and input object
 	Types       []string      // union
 	EnumValues  EnumValueList // enum
+
+	Position *Position `dump:"-"`
 }
 
 func (d *Definition) IsLeafType() bool {
@@ -62,12 +64,14 @@ type FieldDefinition struct {
 	DefaultValue *Value    // only for input objects
 	Type         *Type
 	Directives   DirectiveList
+	Position     *Position `dump:"-"`
 }
 
 type EnumValueDefinition struct {
 	Description string
 	Name        string
 	Directives  DirectiveList
+	Position    *Position `dump:"-"`
 }
 
 // Directive Definitions
@@ -77,4 +81,5 @@ type DirectiveDefinition struct {
 	Name        string
 	Arguments   FieldList
 	Locations   []DirectiveLocation
+	Position    *Position `dump:"-"`
 }

--- a/ast/directive.go
+++ b/ast/directive.go
@@ -29,6 +29,7 @@ const (
 type Directive struct {
 	Name      string
 	Arguments ArgumentList
+	Position  *Position `dump:"-"`
 
 	// Requires validation
 	ParentDefinition *Definition

--- a/ast/document.go
+++ b/ast/document.go
@@ -3,6 +3,7 @@ package ast
 type QueryDocument struct {
 	Operations OperationList
 	Fragments  FragmentDefinitionList
+	Position   *Position `dump:"-"`
 }
 
 type SchemaDocument struct {
@@ -11,6 +12,7 @@ type SchemaDocument struct {
 	Directives      DirectiveDefinitionList
 	Definitions     DefinitionList
 	Extensions      DefinitionList
+	Position        *Position `dump:"-"`
 }
 
 func (d *SchemaDocument) Merge(other *SchemaDocument) {
@@ -25,11 +27,13 @@ type SchemaDefinition struct {
 	Description    string
 	Directives     DirectiveList
 	OperationTypes OperationTypeDefinitionList
+	Position       *Position `dump:"-"`
 }
 
 type OperationTypeDefinition struct {
 	Operation Operation
 	Type      string
+	Position  *Position `dump:"-"`
 }
 
 type Schema struct {

--- a/ast/document_test.go
+++ b/ast/document_test.go
@@ -31,24 +31,24 @@ func TestQueryDocMethods(t *testing.T) {
 }
 
 func TestNamedTypeCompatability(t *testing.T) {
-	assert.True(t, NamedType("A").IsCompatible(NamedType("A")))
-	assert.False(t, NamedType("A").IsCompatible(NamedType("B")))
+	assert.True(t, NamedType("A", nil).IsCompatible(NamedType("A", nil)))
+	assert.False(t, NamedType("A", nil).IsCompatible(NamedType("B", nil)))
 
-	assert.True(t, ListType(NamedType("A")).IsCompatible(ListType(NamedType("A"))))
-	assert.False(t, ListType(NamedType("A")).IsCompatible(ListType(NamedType("B"))))
-	assert.False(t, ListType(NamedType("A")).IsCompatible(ListType(NamedType("B"))))
+	assert.True(t, ListType(NamedType("A", nil), nil).IsCompatible(ListType(NamedType("A", nil), nil)))
+	assert.False(t, ListType(NamedType("A", nil), nil).IsCompatible(ListType(NamedType("B", nil), nil)))
+	assert.False(t, ListType(NamedType("A", nil), nil).IsCompatible(ListType(NamedType("B", nil), nil)))
 
-	assert.True(t, ListType(NamedType("A")).IsCompatible(ListType(NamedType("A"))))
-	assert.False(t, ListType(NamedType("A")).IsCompatible(ListType(NamedType("B"))))
-	assert.False(t, ListType(NamedType("A")).IsCompatible(ListType(NamedType("B"))))
+	assert.True(t, ListType(NamedType("A", nil), nil).IsCompatible(ListType(NamedType("A", nil), nil)))
+	assert.False(t, ListType(NamedType("A", nil), nil).IsCompatible(ListType(NamedType("B", nil), nil)))
+	assert.False(t, ListType(NamedType("A", nil), nil).IsCompatible(ListType(NamedType("B", nil), nil)))
 
-	assert.True(t, NonNullNamedType("A").IsCompatible(NamedType("A")))
-	assert.False(t, NamedType("A").IsCompatible(NonNullNamedType("A")))
+	assert.True(t, NonNullNamedType("A", nil).IsCompatible(NamedType("A", nil)))
+	assert.False(t, NamedType("A", nil).IsCompatible(NonNullNamedType("A", nil)))
 
-	assert.True(t, NonNullListType(NamedType("String")).IsCompatible(NonNullListType(NamedType("String"))))
-	assert.True(t, NonNullListType(NamedType("String")).IsCompatible(ListType(NamedType("String"))))
-	assert.False(t, ListType(NamedType("String")).IsCompatible(NonNullListType(NamedType("String"))))
+	assert.True(t, NonNullListType(NamedType("String", nil), nil).IsCompatible(NonNullListType(NamedType("String", nil), nil)))
+	assert.True(t, NonNullListType(NamedType("String", nil), nil).IsCompatible(ListType(NamedType("String", nil), nil)))
+	assert.False(t, ListType(NamedType("String", nil), nil).IsCompatible(NonNullListType(NamedType("String", nil), nil)))
 
-	assert.True(t, ListType(NonNullNamedType("String")).IsCompatible(ListType(NamedType("String"))))
-	assert.False(t, ListType(NamedType("String")).IsCompatible(ListType(NonNullNamedType("String"))))
+	assert.True(t, ListType(NonNullNamedType("String", nil), nil).IsCompatible(ListType(NamedType("String", nil), nil)))
+	assert.False(t, ListType(NamedType("String", nil), nil).IsCompatible(ListType(NonNullNamedType("String", nil), nil)))
 }

--- a/ast/fragment.go
+++ b/ast/fragment.go
@@ -7,6 +7,8 @@ type FragmentSpread struct {
 	// Require validation
 	ObjectDefinition *Definition
 	Definition       *FragmentDefinition
+
+	Position *Position `dump:"-"`
 }
 
 type InlineFragment struct {
@@ -16,6 +18,8 @@ type InlineFragment struct {
 
 	// Require validation
 	ObjectDefinition *Definition
+
+	Position *Position `dump:"-"`
 }
 
 type FragmentDefinition struct {
@@ -29,4 +33,6 @@ type FragmentDefinition struct {
 
 	// Require validation
 	Definition *Definition
+
+	Position *Position `dump:"-"`
 }

--- a/ast/operation.go
+++ b/ast/operation.go
@@ -14,12 +14,14 @@ type OperationDefinition struct {
 	VariableDefinitions VariableDefinitionList
 	Directives          DirectiveList
 	SelectionSet        SelectionSet
+	Position            *Position `dump:"-"`
 }
 
 type VariableDefinition struct {
 	Variable     string
 	Type         *Type
 	DefaultValue *Value
+	Position     *Position `dump:"-"`
 
 	// Requires validation
 	Definition *Definition

--- a/ast/selection.go
+++ b/ast/selection.go
@@ -4,11 +4,16 @@ type SelectionSet []Selection
 
 type Selection interface {
 	isSelection()
+	GetPosition() *Position
 }
 
 func (*Field) isSelection()          {}
 func (*FragmentSpread) isSelection() {}
 func (*InlineFragment) isSelection() {}
+
+func (s *Field) GetPosition() *Position          { return s.Position }
+func (s *FragmentSpread) GetPosition() *Position { return s.Position }
+func (s *InlineFragment) GetPosition() *Position { return s.Position }
 
 type Field struct {
 	Alias        string

--- a/ast/selection.go
+++ b/ast/selection.go
@@ -16,6 +16,7 @@ type Field struct {
 	Arguments    ArgumentList
 	Directives   DirectiveList
 	SelectionSet SelectionSet
+	Position     *Position `dump:"-"`
 
 	// Require validation
 	Definition       *FieldDefinition
@@ -23,6 +24,7 @@ type Field struct {
 }
 
 type Argument struct {
-	Name  string
-	Value *Value
+	Name     string
+	Value    *Value
+	Position *Position `dump:"-"`
 }

--- a/ast/source.go
+++ b/ast/source.go
@@ -5,7 +5,10 @@ type Source struct {
 	Input string
 }
 
-type Location struct {
-	Line   int
-	Column int
+type Position struct {
+	Start  int     // The starting position, in runes, of this token in the input.
+	End    int     // The end position, in runes, of this token in the input.
+	Line   int     // The line number at the start of this item.
+	Column int     // The line number at the start of this item.
+	Src    *Source // The source document this token belongs to
 }

--- a/ast/type.go
+++ b/ast/type.go
@@ -1,25 +1,26 @@
 package ast
 
-func NonNullNamedType(named string) *Type {
-	return &Type{NamedType: named, NonNull: true}
+func NonNullNamedType(named string, pos *Position) *Type {
+	return &Type{NamedType: named, NonNull: true, Position: pos}
 }
 
-func NamedType(named string) *Type {
-	return &Type{NamedType: named, NonNull: false}
+func NamedType(named string, pos *Position) *Type {
+	return &Type{NamedType: named, NonNull: false, Position: pos}
 }
 
-func NonNullListType(elem *Type) *Type {
-	return &Type{Elem: elem, NonNull: true}
+func NonNullListType(elem *Type, pos *Position) *Type {
+	return &Type{Elem: elem, NonNull: true, Position: pos}
 }
 
-func ListType(elem *Type) *Type {
-	return &Type{Elem: elem, NonNull: false}
+func ListType(elem *Type, pos *Position) *Type {
+	return &Type{Elem: elem, NonNull: false, Position: pos}
 }
 
 type Type struct {
 	NamedType string
 	Elem      *Type
 	NonNull   bool
+	Position  *Position `dump:"-"`
 }
 
 func (t *Type) Name() string {

--- a/ast/value.go
+++ b/ast/value.go
@@ -25,16 +25,18 @@ type Value struct {
 	Raw      string
 	Children ChildValueList
 	Kind     ValueKind
+	Position *Position `dump:"-"`
 
-	// Require validation a mouse from the cupboard
+	// Require validation
 	Definition         *Definition
 	VariableDefinition *VariableDefinition
 	ExpectedType       *Type
 }
 
 type ChildValue struct {
-	Name  string
-	Value *Value
+	Name     string
+	Value    *Value
+	Position *Position `dump:"-"`
 }
 
 func (v *Value) Value(vars map[string]interface{}) (interface{}, error) {

--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -15,6 +15,17 @@ type Error struct {
 	Rule       string                 `json:"-"`
 }
 
+func (err *Error) SetFile(file string) {
+	if file == "" {
+		return
+	}
+	if err.Extensions == nil {
+		err.Extensions = map[string]interface{}{}
+	}
+
+	err.Extensions["file"] = file
+}
+
 type Location struct {
 	Line   int `json:"line,omitempty"`
 	Column int `json:"column,omitempty"`

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -43,25 +43,29 @@ func (s *Lexer) makeToken(kind Type) (Token, *gqlerror.Error) {
 
 func (s *Lexer) makeValueToken(kind Type, value string) (Token, *gqlerror.Error) {
 	return Token{
-		Kind:   kind,
-		Start:  s.startRunes,
-		End:    s.endRunes,
-		Value:  value,
-		Line:   s.line,
-		Column: s.startRunes - s.lineStartRunes + 1,
-		Src:    s.Source,
+		Kind:  kind,
+		Value: value,
+		Pos: ast.Position{
+			Start:  s.startRunes,
+			End:    s.endRunes,
+			Line:   s.line,
+			Column: s.startRunes - s.lineStartRunes + 1,
+			Src:    s.Source,
+		},
 	}, nil
 }
 
 func (s *Lexer) makeError(format string, args ...interface{}) (Token, *gqlerror.Error) {
 	column := s.endRunes - s.lineStartRunes + 1
 	return Token{
-		Kind:   Invalid,
-		Start:  s.startRunes,
-		End:    s.endRunes,
-		Line:   s.line,
-		Column: column,
-		Src:    s.Source,
+		Kind: Invalid,
+		Pos: ast.Position{
+			Start:  s.startRunes,
+			End:    s.endRunes,
+			Line:   s.line,
+			Column: column,
+			Src:    s.Source,
+		},
 	}, gqlerror.ErrorLocf(s.Source.Name, s.line, column, format, args...)
 }
 
@@ -332,8 +336,8 @@ func (s *Lexer) readString() (Token, *gqlerror.Error) {
 		case '"':
 			t, err := s.makeToken(String)
 			// the token should not include the quotes in its value, but should cover them in its position
-			t.Start--
-			t.End++
+			t.Pos.Start--
+			t.Pos.End++
 
 			if buf != nil {
 				t.Value = buf.String()
@@ -424,8 +428,8 @@ func (s *Lexer) readBlockString() (Token, *gqlerror.Error) {
 			t, err := s.makeValueToken(BlockString, blockStringValue(buf.String()))
 
 			// the token should not include the quotes in its value, but should cover them in its position
-			t.Start -= 3
-			t.End += 3
+			t.Pos.Start -= 3
+			t.Pos.End += 3
 
 			// skip the close quote
 			s.end += 3

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -27,11 +27,11 @@ func TestLexer(t *testing.T) {
 			ret.Tokens = append(ret.Tokens, spec.Token{
 				Kind:   tok.Kind.Name(),
 				Value:  tok.Value,
-				Line:   tok.Line,
-				Column: tok.Column,
-				Start:  tok.Start,
-				End:    tok.End,
-				Src:    tok.Src.Name,
+				Line:   tok.Pos.Line,
+				Column: tok.Pos.Column,
+				Start:  tok.Pos.Start,
+				End:    tok.Pos.End,
+				Src:    tok.Pos.Src.Name,
 			})
 		}
 

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -135,13 +135,9 @@ func (t Type) String() string {
 type Type int
 
 type Token struct {
-	Kind   Type        // The token type.
-	Value  string      // The literal value consumed.
-	Start  int         // The starting position, in runes, of this token in the input.
-	End    int         // The end position, in runes, of this token in the input.
-	Line   int         // The line number at the start of this item.
-	Column int         // The line number at the start of this item.
-	Src    *ast.Source // The source document this token belongs to
+	Kind  Type         // The token type.
+	Value string       // The literal value consumed.
+	Pos   ast.Position // The file and line this token was read from
 }
 
 func (t Token) String() string {

--- a/parser/loader.go
+++ b/parser/loader.go
@@ -115,13 +115,13 @@ func LoadSchema(inputs ...*Source) (*Schema, *gqlerror.Error) {
 			schema.Query.Fields,
 			&FieldDefinition{
 				Name: "__schema",
-				Type: NonNullNamedType("__Schema"),
+				Type: NonNullNamedType("__Schema", nil),
 			},
 			&FieldDefinition{
 				Name: "__type",
-				Type: NonNullNamedType("__Type"),
+				Type: NonNullNamedType("__Type", nil),
 				Arguments: FieldList{
-					{Name: "name", Type: NamedType("String")},
+					{Name: "name", Type: NamedType("String", nil)},
 				},
 			},
 		)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"strconv"
 
+	"github.com/vektah/gqlparser/ast"
 	"github.com/vektah/gqlparser/gqlerror"
 	"github.com/vektah/gqlparser/lexer"
 )
@@ -16,6 +17,15 @@ type parser struct {
 	peekError *gqlerror.Error
 
 	prev lexer.Token
+}
+
+func (p *parser) peekPos() *ast.Position {
+	if p.err != nil {
+		return nil
+	}
+
+	peek := p.peek()
+	return &peek.Pos
 }
 
 func (p *parser) peek() lexer.Token {
@@ -35,7 +45,7 @@ func (p *parser) error(tok lexer.Token, format string, args ...interface{}) {
 	if p.err != nil {
 		return
 	}
-	p.err = gqlerror.ErrorLocf(tok.Src.Name, tok.Line, tok.Column, format, args...)
+	p.err = gqlerror.ErrorLocf(tok.Pos.Src.Name, tok.Pos.Line, tok.Pos.Column, format, args...)
 }
 
 func (p *parser) next() lexer.Token {

--- a/parser/query.go
+++ b/parser/query.go
@@ -257,20 +257,22 @@ func (p *parser) parseValueLiteral(isConst bool) *Value {
 
 func (p *parser) parseList(isConst bool) *Value {
 	var values ChildValueList
+	pos := p.peekPos()
 	p.many(lexer.BracketL, lexer.BracketR, func() {
 		values = append(values, &ChildValue{Value: p.parseValueLiteral(isConst)})
 	})
 
-	return &Value{Children: values, Kind: ListValue}
+	return &Value{Children: values, Kind: ListValue, Position: pos}
 }
 
 func (p *parser) parseObject(isConst bool) *Value {
 	var fields ChildValueList
+	pos := p.peekPos()
 	p.many(lexer.BraceL, lexer.BraceR, func() {
 		fields = append(fields, p.parseObjectField(isConst))
 	})
 
-	return &Value{Children: fields, Kind: ObjectValue}
+	return &Value{Children: fields, Kind: ObjectValue, Position: pos}
 }
 
 func (p *parser) parseObjectField(isConst bool) *ChildValue {

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -15,6 +15,7 @@ func ParseSchema(source *Source) (*SchemaDocument, *gqlerror.Error) {
 
 func (p *parser) parseSchemaDocument() *SchemaDocument {
 	var doc SchemaDocument
+	doc.Position = p.peekPos()
 	for p.peek().Kind != lexer.EOF {
 		if p.err != nil {
 			return nil
@@ -91,6 +92,7 @@ func (p *parser) parseSchemaDefinition(description string) *SchemaDefinition {
 	p.expectKeyword("schema")
 
 	def := SchemaDefinition{Description: description}
+	def.Position = p.peekPos()
 	def.Description = description
 	def.Directives = p.parseDirectives(true)
 
@@ -102,6 +104,7 @@ func (p *parser) parseSchemaDefinition(description string) *SchemaDefinition {
 
 func (p *parser) parseOperationTypeDefinition() *OperationTypeDefinition {
 	var op OperationTypeDefinition
+	op.Position = p.peekPos()
 	op.Operation = p.parseOperationType()
 	p.expect(lexer.Colon)
 	op.Type = p.parseName()
@@ -112,6 +115,7 @@ func (p *parser) parseScalarTypeDefinition(description string) *Definition {
 	p.expectKeyword("scalar")
 
 	var def Definition
+	def.Position = p.peekPos()
 	def.Kind = Scalar
 	def.Description = description
 	def.Name = p.parseName()
@@ -123,6 +127,7 @@ func (p *parser) parseObjectTypeDefinition(description string) *Definition {
 	p.expectKeyword("type")
 
 	var def Definition
+	def.Position = p.peekPos()
 	def.Kind = Object
 	def.Description = description
 	def.Name = p.parseName()
@@ -157,7 +162,7 @@ func (p *parser) parseFieldsDefinition() FieldList {
 
 func (p *parser) parseFieldDefinition() *FieldDefinition {
 	var def FieldDefinition
-
+	def.Position = p.peekPos()
 	def.Description = p.parseDescription()
 	def.Name = p.parseName()
 	def.Arguments = p.parseArgumentDefs()
@@ -178,6 +183,7 @@ func (p *parser) parseArgumentDefs() FieldList {
 
 func (p *parser) parseInputValueDef() *FieldDefinition {
 	var def FieldDefinition
+	def.Position = p.peekPos()
 	def.Description = p.parseDescription()
 	def.Name = p.parseName()
 	p.expect(lexer.Colon)
@@ -193,6 +199,7 @@ func (p *parser) parseInterfaceTypeDefinition(description string) *Definition {
 	p.expectKeyword("interface")
 
 	var def Definition
+	def.Position = p.peekPos()
 	def.Kind = Interface
 	def.Description = description
 	def.Name = p.parseName()
@@ -205,6 +212,7 @@ func (p *parser) parseUnionTypeDefinition(description string) *Definition {
 	p.expectKeyword("union")
 
 	var def Definition
+	def.Position = p.peekPos()
 	def.Kind = Union
 	def.Description = description
 	def.Name = p.parseName()
@@ -231,6 +239,7 @@ func (p *parser) parseEnumTypeDefinition(description string) *Definition {
 	p.expectKeyword("enum")
 
 	var def Definition
+	def.Position = p.peekPos()
 	def.Kind = Enum
 	def.Description = description
 	def.Name = p.parseName()
@@ -249,6 +258,7 @@ func (p *parser) parseEnumValuesDefinition() EnumValueList {
 
 func (p *parser) parseEnumValueDefinition() *EnumValueDefinition {
 	return &EnumValueDefinition{
+		Position:    p.peekPos(),
 		Description: p.parseDescription(),
 		Name:        p.parseName(),
 		Directives:  p.parseDirectives(true),
@@ -259,6 +269,7 @@ func (p *parser) parseInputObjectTypeDefinition(description string) *Definition 
 	p.expectKeyword("input")
 
 	var def Definition
+	def.Position = p.peekPos()
 	def.Kind = InputObject
 	def.Description = description
 	def.Name = p.parseName()
@@ -302,6 +313,7 @@ func (p *parser) parseSchemaExtension() *SchemaDefinition {
 	p.expectKeyword("schema")
 
 	var def SchemaDefinition
+	def.Position = p.peekPos()
 	def.Directives = p.parseDirectives(true)
 	p.many(lexer.BraceL, lexer.BraceR, func() {
 		def.OperationTypes = append(def.OperationTypes, p.parseOperationTypeDefinition())
@@ -316,6 +328,7 @@ func (p *parser) parseScalarTypeExtension() *Definition {
 	p.expectKeyword("scalar")
 
 	var def Definition
+	def.Position = p.peekPos()
 	def.Kind = Scalar
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
@@ -329,6 +342,7 @@ func (p *parser) parseObjectTypeExtension() *Definition {
 	p.expectKeyword("type")
 
 	var def Definition
+	def.Position = p.peekPos()
 	def.Kind = Object
 	def.Name = p.parseName()
 	def.Interfaces = p.parseImplementsInterfaces()
@@ -344,6 +358,7 @@ func (p *parser) parseInterfaceTypeExtension() *Definition {
 	p.expectKeyword("interface")
 
 	var def Definition
+	def.Position = p.peekPos()
 	def.Kind = Interface
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
@@ -358,6 +373,7 @@ func (p *parser) parseUnionTypeExtension() *Definition {
 	p.expectKeyword("union")
 
 	var def Definition
+	def.Position = p.peekPos()
 	def.Kind = Union
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
@@ -373,6 +389,7 @@ func (p *parser) parseEnumTypeExtension() *Definition {
 	p.expectKeyword("enum")
 
 	var def Definition
+	def.Position = p.peekPos()
 	def.Kind = Enum
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
@@ -387,6 +404,7 @@ func (p *parser) parseInputObjectTypeExtension() *Definition {
 	p.expectKeyword("input")
 
 	var def Definition
+	def.Position = p.peekPos()
 	def.Kind = InputObject
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(false)
@@ -402,6 +420,7 @@ func (p *parser) parseDirectiveDefinition(description string) *DirectiveDefiniti
 	p.expect(lexer.At)
 
 	var def DirectiveDefinition
+	def.Position = p.peekPos()
 	def.Description = description
 	def.Name = p.parseName()
 	def.Arguments = p.parseArgumentDefs()

--- a/validator/error.go
+++ b/validator/error.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"fmt"
 
+	"github.com/vektah/gqlparser/ast"
 	"github.com/vektah/gqlparser/gqlerror"
 )
 
@@ -11,6 +12,21 @@ type ErrorOption func(err *gqlerror.Error)
 func Message(msg string, args ...interface{}) ErrorOption {
 	return func(err *gqlerror.Error) {
 		err.Message += fmt.Sprintf(msg, args...)
+	}
+}
+
+func At(position *ast.Position) ErrorOption {
+	return func(err *gqlerror.Error) {
+		if position == nil {
+			return
+		}
+		err.Locations = append(err.Locations, gqlerror.Location{
+			Line:   position.Line,
+			Column: position.Column,
+		})
+		if position.Src.Name != "" {
+			err.SetFile(position.Src.Name)
+		}
 	}
 }
 

--- a/validator/rules/fields_on_correct_type.go
+++ b/validator/rules/fields_on_correct_type.go
@@ -23,7 +23,10 @@ func init() {
 				message += " Did you mean " + QuotedOrList(suggestedFieldNames...) + "?"
 			}
 
-			addError(Message(message))
+			addError(
+				Message(message),
+				At(field.Position),
+			)
 		})
 	})
 }

--- a/validator/rules/fragments_on_composite_types.go
+++ b/validator/rules/fragments_on_composite_types.go
@@ -17,7 +17,10 @@ func init() {
 
 			message := fmt.Sprintf(`Fragment cannot condition on non composite type "%s".`, inlineFragment.TypeCondition)
 
-			addError(Message(message))
+			addError(
+				Message(message),
+				At(inlineFragment.Position),
+			)
 		})
 
 		observers.OnFragment(func(walker *Walker, fragment *ast.FragmentDefinition) {
@@ -27,7 +30,10 @@ func init() {
 
 			message := fmt.Sprintf(`Fragment "%s" cannot condition on non composite type "%s".`, fragment.Name, fragment.TypeCondition)
 
-			addError(Message(message))
+			addError(
+				Message(message),
+				At(fragment.Position),
+			)
 		})
 	})
 }

--- a/validator/rules/known_argument_names.go
+++ b/validator/rules/known_argument_names.go
@@ -26,6 +26,7 @@ func init() {
 				addError(
 					Message(`Unknown argument "%s" on field "%s" of type "%s".`, arg.Name, field.Name, field.ObjectDefinition.Name),
 					SuggestListQuoted("Did you mean", arg.Name, suggestions),
+					At(field.Position),
 				)
 			}
 		})
@@ -48,6 +49,7 @@ func init() {
 				addError(
 					Message(`Unknown argument "%s" on directive "@%s".`, arg.Name, directive.Name),
 					SuggestListQuoted("Did you mean", arg.Name, suggestions),
+					At(directive.Position),
 				)
 			}
 		})

--- a/validator/rules/known_directives.go
+++ b/validator/rules/known_directives.go
@@ -11,6 +11,7 @@ func init() {
 			if directive.Definition == nil {
 				addError(
 					Message(`Unknown directive "%s".`, directive.Name),
+					At(directive.Position),
 				)
 				return
 			}
@@ -23,6 +24,7 @@ func init() {
 
 			addError(
 				Message(`Directive "%s" may not be used on %s.`, directive.Name, directive.Location),
+				At(directive.Position),
 			)
 		})
 	})

--- a/validator/rules/known_fragment_names.go
+++ b/validator/rules/known_fragment_names.go
@@ -9,7 +9,10 @@ func init() {
 	AddRule("KnownFragmentNames", func(observers *Events, addError AddErrFunc) {
 		observers.OnFragmentSpread(func(walker *Walker, fragmentSpread *ast.FragmentSpread) {
 			if fragmentSpread.Definition == nil {
-				addError(Message(`Unknown fragment "%s".`, fragmentSpread.Name))
+				addError(
+					Message(`Unknown fragment "%s".`, fragmentSpread.Name),
+					At(fragmentSpread.Position),
+				)
 			}
 		})
 	})

--- a/validator/rules/known_type_names.go
+++ b/validator/rules/known_type_names.go
@@ -17,6 +17,7 @@ func init() {
 
 				addError(
 					Message(`Unknown type "%s".`, typeName),
+					At(operation.Position),
 				)
 			}
 		})
@@ -34,6 +35,7 @@ func init() {
 
 			addError(
 				Message(`Unknown type "%s".`, typedName),
+				At(inlineFragment.Position),
 			)
 		})
 
@@ -49,11 +51,10 @@ func init() {
 				possibleTypes = append(possibleTypes, t.Name)
 			}
 
-			list := SuggestListQuoted("Did you mean", typeName, possibleTypes)
-
 			addError(
 				Message(`Unknown type "%s".`, typeName),
-				list,
+				SuggestListQuoted("Did you mean", typeName, possibleTypes),
+				At(fragment.Position),
 			)
 		})
 	})

--- a/validator/rules/lone_anonymous_operation.go
+++ b/validator/rules/lone_anonymous_operation.go
@@ -9,7 +9,10 @@ func init() {
 	AddRule("LoneAnonymousOperation", func(observers *Events, addError AddErrFunc) {
 		observers.OnOperation(func(walker *Walker, operation *ast.OperationDefinition) {
 			if operation.Name == "" && len(walker.Document.Operations) > 1 {
-				addError(Message(`This anonymous operation must be the only defined operation.`))
+				addError(
+					Message(`This anonymous operation must be the only defined operation.`),
+					At(operation.Position),
+				)
 			}
 		})
 	})

--- a/validator/rules/no_fragment_cycles.go
+++ b/validator/rules/no_fragment_cycles.go
@@ -51,7 +51,10 @@ func init() {
 						if len(fragmentNames) != 0 {
 							via = fmt.Sprintf(" via %s", strings.Join(fragmentNames, ", "))
 						}
-						addError(Message(`Cannot spread fragment "%s" within itself%s.`, spreadName, via))
+						addError(
+							Message(`Cannot spread fragment "%s" within itself%s.`, spreadName, via),
+							At(spreadNode.Position),
+						)
 					}
 
 					spreadPath = spreadPath[:len(spreadPath)-1]

--- a/validator/rules/no_undefined_variables.go
+++ b/validator/rules/no_undefined_variables.go
@@ -13,9 +13,15 @@ func init() {
 			}
 
 			if walker.CurrentOperation.Name != "" {
-				addError(Message(`Variable "$%s" is not defined by operation "%s".`, value, walker.CurrentOperation.Name))
+				addError(
+					Message(`Variable "$%s" is not defined by operation "%s".`, value, walker.CurrentOperation.Name),
+					At(walker.CurrentOperation.Position),
+				)
 			} else {
-				addError(Message(`Variable "$%s" is not defined.`, value))
+				addError(
+					Message(`Variable "$%s" is not defined.`, value),
+					At(value.Position),
+				)
 			}
 		})
 	})

--- a/validator/rules/no_unused_fragments.go
+++ b/validator/rules/no_unused_fragments.go
@@ -20,7 +20,10 @@ func init() {
 		observers.OnFragment(func(walker *Walker, fragment *ast.FragmentDefinition) {
 			inFragmentDefinition = true
 			if !fragmentNameUsed[fragment.Name] {
-				addError(Message(`Fragment "%s" is never used.`, fragment.Name))
+				addError(
+					Message(`Fragment "%s" is never used.`, fragment.Name),
+					At(fragment.Position),
+				)
 			}
 		})
 	})

--- a/validator/rules/no_unused_variables.go
+++ b/validator/rules/no_unused_variables.go
@@ -14,9 +14,15 @@ func init() {
 				}
 
 				if operation.Name != "" {
-					addError(Message(`Variable "$%s" is never used in operation "%s".`, varDef.Variable, operation.Name))
+					addError(
+						Message(`Variable "$%s" is never used in operation "%s".`, varDef.Variable, operation.Name),
+						At(varDef.Position),
+					)
 				} else {
-					addError(Message(`Variable "$%s" is never used.`, varDef.Variable))
+					addError(
+						Message(`Variable "$%s" is never used.`, varDef.Variable),
+						At(varDef.Position),
+					)
 				}
 			}
 		})

--- a/validator/rules/possible_fragment_spreads.go
+++ b/validator/rules/possible_fragment_spreads.go
@@ -46,7 +46,10 @@ func init() {
 
 		observers.OnInlineFragment(func(walker *Walker, inlineFragment *ast.InlineFragment) {
 			validate(walker, inlineFragment.ObjectDefinition, inlineFragment.TypeCondition, func() {
-				addError(Message(`Fragment cannot be spread here as objects of type "%s" can never be of type "%s".`, inlineFragment.ObjectDefinition.Name, inlineFragment.TypeCondition))
+				addError(
+					Message(`Fragment cannot be spread here as objects of type "%s" can never be of type "%s".`, inlineFragment.ObjectDefinition.Name, inlineFragment.TypeCondition),
+					At(inlineFragment.Position),
+				)
 			})
 		})
 
@@ -55,7 +58,10 @@ func init() {
 				return
 			}
 			validate(walker, fragmentSpread.ObjectDefinition, fragmentSpread.Definition.TypeCondition, func() {
-				addError(Message(`Fragment "%s" cannot be spread here as objects of type "%s" can never be of type "%s".`, fragmentSpread.Name, fragmentSpread.ObjectDefinition.Name, fragmentSpread.Definition.TypeCondition))
+				addError(
+					Message(`Fragment "%s" cannot be spread here as objects of type "%s" can never be of type "%s".`, fragmentSpread.Name, fragmentSpread.ObjectDefinition.Name, fragmentSpread.Definition.TypeCondition),
+					At(fragmentSpread.Position),
+				)
 			})
 		})
 	})

--- a/validator/rules/provided_required_arguments.go
+++ b/validator/rules/provided_required_arguments.go
@@ -27,7 +27,10 @@ func init() {
 					}
 				}
 
-				addError(Message(`Field "%s" argument "%s" of type "%s" is required but not provided.`, field.Name, argDef.Name, argDef.Type.String()))
+				addError(
+					Message(`Field "%s" argument "%s" of type "%s" is required but not provided.`, field.Name, argDef.Name, argDef.Type.String()),
+					At(field.Position),
+				)
 			}
 		})
 
@@ -50,7 +53,10 @@ func init() {
 					}
 				}
 
-				addError(Message(`Directive "@%s" argument "%s" of type "%s" is required but not provided.`, directive.Definition.Name, argDef.Name, argDef.Type.String()))
+				addError(
+					Message(`Directive "@%s" argument "%s" of type "%s" is required but not provided.`, directive.Definition.Name, argDef.Name, argDef.Type.String()),
+					At(directive.Position),
+				)
 			}
 		})
 	})

--- a/validator/rules/scalar_leafs.go
+++ b/validator/rules/scalar_leafs.go
@@ -20,6 +20,7 @@ func init() {
 			if fieldType.IsLeafType() && len(field.SelectionSet) > 0 {
 				addError(
 					Message(`Field "%s" must not have a selection since type "%s" has no subfields.`, field.Name, fieldType.Name),
+					At(field.Position),
 				)
 			}
 
@@ -27,6 +28,7 @@ func init() {
 				addError(
 					Message(`Field "%s" of type "%s" must have a selection of subfields.`, field.Name, field.Definition.Type.String()),
 					Suggestf(`"%s { ... }"`, field.Name),
+					At(field.Position),
 				)
 			}
 		})

--- a/validator/rules/single_field_subscriptions.go
+++ b/validator/rules/single_field_subscriptions.go
@@ -14,7 +14,7 @@ func init() {
 				return
 			}
 
-			if len(operation.SelectionSet) != 1 {
+			if len(operation.SelectionSet) > 1 {
 				name := "Anonymous Subscription"
 				if operation.Name != "" {
 					name = `Subscription ` + strconv.Quote(operation.Name)
@@ -22,6 +22,7 @@ func init() {
 
 				addError(
 					Message(`%s must select only one top level field.`, name),
+					At(operation.SelectionSet[1].GetPosition()),
 				)
 			}
 		})

--- a/validator/rules/unique_argument_names.go
+++ b/validator/rules/unique_argument_names.go
@@ -24,6 +24,7 @@ func checkUniqueArgs(args ast.ArgumentList, addError AddErrFunc) {
 		if knownArgNames[arg.Name] {
 			addError(
 				Message(`There can be only one argument named "%s".`, arg.Name),
+				At(arg.Position),
 			)
 		}
 

--- a/validator/rules/unique_directives_per_location.go
+++ b/validator/rules/unique_directives_per_location.go
@@ -14,6 +14,7 @@ func init() {
 				if seen[dir.Name] {
 					addError(
 						Message(`The directive "%s" can only be used once at this location.`, dir.Name),
+						At(dir.Position),
 					)
 				}
 				seen[dir.Name] = true

--- a/validator/rules/unique_fragment_names.go
+++ b/validator/rules/unique_fragment_names.go
@@ -13,6 +13,7 @@ func init() {
 			if seenFragments[fragment.Name] {
 				addError(
 					Message(`There can be only one fragment named "%s".`, fragment.Name),
+					At(fragment.Position),
 				)
 			}
 			seenFragments[fragment.Name] = true

--- a/validator/rules/unique_input_field_names.go
+++ b/validator/rules/unique_input_field_names.go
@@ -17,6 +17,7 @@ func init() {
 				if seen[field.Name] {
 					addError(
 						Message(`There can be only one input field named "%s".`, field.Name),
+						At(field.Position),
 					)
 				}
 				seen[field.Name] = true

--- a/validator/rules/unique_operation_names.go
+++ b/validator/rules/unique_operation_names.go
@@ -13,6 +13,7 @@ func init() {
 			if seen[operation.Name] {
 				addError(
 					Message(`There can be only one operation named "%s".`, operation.Name),
+					At(operation.Position),
 				)
 			}
 			seen[operation.Name] = true

--- a/validator/rules/unique_variable_names.go
+++ b/validator/rules/unique_variable_names.go
@@ -11,7 +11,10 @@ func init() {
 			seen := map[string]bool{}
 			for _, def := range operation.VariableDefinitions {
 				if seen[def.Variable] {
-					addError(Message(`There can be only one variable named "%s".`, def.Variable))
+					addError(
+						Message(`There can be only one variable named "%s".`, def.Variable),
+						At(def.Position),
+					)
 				}
 				seen[def.Variable] = true
 			}

--- a/validator/rules/variables_are_input_types.go
+++ b/validator/rules/variables_are_input_types.go
@@ -19,6 +19,7 @@ func init() {
 							def.Variable,
 							def.Type.String(),
 						),
+						At(def.Position),
 					)
 				}
 			}

--- a/validator/rules/variables_in_allowed_position.go
+++ b/validator/rules/variables_in_allowed_position.go
@@ -28,6 +28,7 @@ func init() {
 						value.VariableDefinition.Type.String(),
 						value.ExpectedType.String(),
 					),
+					At(value.Position),
 				)
 			}
 		})

--- a/validator/walk.go
+++ b/validator/walk.go
@@ -213,7 +213,7 @@ func (w *Walker) walkSelection(parentDef *ast.Definition, it ast.Selection) {
 		if it.Name == "__typename" {
 			def = &ast.FieldDefinition{
 				Name: "__typename",
-				Type: ast.NamedType("string"),
+				Type: ast.NamedType("string", nil),
 			}
 		} else if parentDef != nil {
 			def = parentDef.Fields.ForName(it.Name)


### PR DESCRIPTION
Adds positions to all ast tokens and emits them during validation.

This is a first cut, its currently only asserting line numbers match one of the lines in the spec. Further iteration should improve the locations.