### PR TITLE
check for self-referential directives

### DIFF
--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -49,6 +49,13 @@ directives:
       message: "Undefined directive foo."
       locations: [{line: 2, column: 17}]
 
+  - name: cannot be self-referential
+    input: |
+      directive @A(foo: Int! @A) on FIELD_DEFINITION
+    error:
+      message: "Directive A cannot refer to itself."
+      locations: [{line: 1, column: 25}]
+
 entry points:
   - name: multiple schema entry points
     input: |


### PR DESCRIPTION
> A directive definition must not contain the use of a directive which references itself directly.
