### PR TITLE
Resolve Default Variable Value

### DIFF
--- a/ast/value.go
+++ b/ast/value.go
@@ -45,7 +45,13 @@ func (v *Value) Value(vars map[string]interface{}) (interface{}, error) {
 	}
 	switch v.Kind {
 	case Variable:
-		return vars[v.Raw], nil
+		if value, ok := vars[v.Raw]; ok {
+			return value, nil
+		}
+		if v.VariableDefinition != nil && v.VariableDefinition.DefaultValue != nil {
+			return v.VariableDefinition.DefaultValue.Value(vars)
+		}
+		return nil, fmt.Errorf("variable not provided: %s", v.Raw)
 	case IntValue:
 		return strconv.ParseInt(v.Raw, 10, 64)
 	case FloatValue:

--- a/ast/value_test.go
+++ b/ast/value_test.go
@@ -1,0 +1,38 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultValue(t *testing.T) {
+	v := Value{
+		Raw:  "foo",
+		Kind: Variable,
+		VariableDefinition: &VariableDefinition{
+			DefaultValue: &Value{
+				Raw:  "99",
+				Kind: IntValue,
+			},
+		},
+	}
+
+	t.Run("returns variable value when provided", func(t *testing.T) {
+		vars := make(map[string]interface{})
+		vars["foo"] = int64(123)
+		value, _ := v.Value(vars)
+		require.Equal(t, int64(123), value)
+	})
+
+	t.Run("resolves default value when variable not provided", func(t *testing.T) {
+		value, _ := v.Value(make(map[string]interface{}))
+		require.Equal(t, int64(99), value)
+	})
+
+	t.Run("returns error when variable has no default", func(t *testing.T) {
+		v := Value{Raw: "foo", Kind: Variable, VariableDefinition: &VariableDefinition{}}
+		_, err := v.Value(make(map[string]interface{}))
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
Updates `Value.Value()` to resolve variable defaults.  Now returns an error if a variable is not provided and has no default value.
