### PR TITLE
Resolve Default From Schema Variable Definintion

### DIFF
--- a/ast/value.go
+++ b/ast/value.go
@@ -30,6 +30,7 @@ type Value struct {
 	// Require validation
 	Definition         *Definition
 	VariableDefinition *VariableDefinition
+	FieldDefinition    *FieldDefinition
 	ExpectedType       *Type
 }
 
@@ -50,6 +51,9 @@ func (v *Value) Value(vars map[string]interface{}) (interface{}, error) {
 		}
 		if v.VariableDefinition != nil && v.VariableDefinition.DefaultValue != nil {
 			return v.VariableDefinition.DefaultValue.Value(vars)
+		}
+		if v.FieldDefinition != nil && v.FieldDefinition.DefaultValue != nil {
+			return v.FieldDefinition.DefaultValue.Value(vars)
 		}
 		return nil, nil
 	case IntValue:

--- a/ast/value_test.go
+++ b/ast/value_test.go
@@ -25,14 +25,24 @@ func TestDefaultValue(t *testing.T) {
 		require.Equal(t, int64(123), value)
 	})
 
-	t.Run("resolves default value when variable not provided", func(t *testing.T) {
+	t.Run("resolves default value from query when variable not provided", func(t *testing.T) {
 		value, _ := v.Value(make(map[string]interface{}))
 		require.Equal(t, int64(99), value)
 	})
 
-	t.Run("returns error when variable has no default", func(t *testing.T) {
-		v := Value{Raw: "foo", Kind: Variable, VariableDefinition: &VariableDefinition{}}
-		_, err := v.Value(make(map[string]interface{}))
-		require.Error(t, err)
+	t.Run("resolves default value from schema when variable not provided", func(t *testing.T) {
+		v := Value{
+			Raw:  "foo",
+			Kind: Variable,
+			FieldDefinition: &FieldDefinition{
+				DefaultValue: &Value{
+					Raw:  "88",
+					Kind: IntValue,
+				},
+			},
+		}
+		v.VariableDefinition = nil
+		value, _ := v.Value(make(map[string]interface{}))
+		require.Equal(t, int64(88), value)
 	})
 }

--- a/validator/walk.go
+++ b/validator/walk.go
@@ -167,6 +167,7 @@ func (w *Walker) walkValue(value *ast.Value) {
 			if value.Definition != nil {
 				fieldDef := value.Definition.Fields.ForName(child.Name)
 				if fieldDef != nil {
+					child.Value.FieldDefinition = fieldDef
 					child.Value.ExpectedType = fieldDef.Type
 					child.Value.Definition = w.Schema.Types[fieldDef.Type.Name()]
 				}


### PR DESCRIPTION
Following on from #46 — that PR does not handle the case where a variable has a default value provided by the schema.  This adds the additional case to `Value.Value` where it will check for the `FieldDefinition` and it's default value in the case that no default has come from the variable.