### PR TITLE
Coerce variables

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -9,5 +9,5 @@
       "PartitionStrategy": "packages"
     }
   },
-  "Disable": ["golint","gocyclo", "goconst", "gas", "interfacer", "vet"]
+  "Disable": ["golint","gocyclo", "goconst", "gas", "interfacer", "vet","gosec"]
 }

--- a/ast/value_test.go
+++ b/ast/value_test.go
@@ -29,10 +29,4 @@ func TestDefaultValue(t *testing.T) {
 		value, _ := v.Value(make(map[string]interface{}))
 		require.Equal(t, int64(99), value)
 	})
-
-	t.Run("returns error when variable has no default", func(t *testing.T) {
-		v := Value{Raw: "foo", Kind: Variable, VariableDefinition: &VariableDefinition{}}
-		_, err := v.Value(make(map[string]interface{}))
-		require.Error(t, err)
-	})
 }

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -10,14 +10,20 @@ func TestErrorFormatting(t *testing.T) {
 	t.Run("without filename", func(t *testing.T) {
 		err := ErrorLocf("", 66, 2, "kabloom")
 
-		require.Equal(t, `input:66 kabloom`, err.Error())
+		require.Equal(t, `input:66: kabloom`, err.Error())
 		require.Equal(t, nil, err.Extensions["file"])
 	})
 
 	t.Run("with filename", func(t *testing.T) {
 		err := ErrorLocf("schema.graphql", 66, 2, "kabloom")
 
-		require.Equal(t, `schema.graphql:66 kabloom`, err.Error())
+		require.Equal(t, `schema.graphql:66: kabloom`, err.Error())
 		require.Equal(t, "schema.graphql", err.Extensions["file"])
+	})
+
+	t.Run("with path", func(t *testing.T) {
+		err := ErrorPathf([]interface{}{"a", 1, "b"}, "kabloom")
+
+		require.Equal(t, `input: a[1].b kabloom`, err.Error())
 	})
 }

--- a/gqlparser.go
+++ b/gqlparser.go
@@ -33,3 +33,11 @@ func LoadQuery(schema *ast.Schema, str string) (*ast.QueryDocument, gqlerror.Lis
 
 	return query, nil
 }
+
+func MustLoadQuery(schema *ast.Schema, str string) *ast.QueryDocument {
+	q, err := LoadQuery(schema, str)
+	if err != nil {
+		panic(err)
+	}
+	return q
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -63,7 +63,7 @@ func TestParserUtils(t *testing.T) {
 				p.error(p.peek(), "boom")
 			}
 		})
-		require.EqualError(t, p.err, "input.graphql:1 boom")
+		require.EqualError(t, p.err, "input.graphql:1: boom")
 		require.Equal(t, []string{"a", "b"}, arr)
 	})
 
@@ -74,7 +74,7 @@ func TestParserUtils(t *testing.T) {
 		p.error(p.peek(), "test error")
 		p.error(p.peek(), "secondary error")
 
-		require.EqualError(t, p.err, "input.graphql:1 test error")
+		require.EqualError(t, p.err, "input.graphql:1: test error")
 
 		require.Equal(t, "foo", p.peek().Value)
 		require.Equal(t, "foo", p.next().Value)
@@ -84,27 +84,27 @@ func TestParserUtils(t *testing.T) {
 	t.Run("unexpected error", func(t *testing.T) {
 		p := newParser("1 3")
 		p.unexpectedError()
-		require.EqualError(t, p.err, "input.graphql:1 Unexpected Int \"1\"")
+		require.EqualError(t, p.err, "input.graphql:1: Unexpected Int \"1\"")
 	})
 
 	t.Run("unexpected error", func(t *testing.T) {
 		p := newParser("1 3")
 		p.unexpectedToken(p.next())
-		require.EqualError(t, p.err, "input.graphql:1 Unexpected Int \"1\"")
+		require.EqualError(t, p.err, "input.graphql:1: Unexpected Int \"1\"")
 	})
 
 	t.Run("expect error", func(t *testing.T) {
 		p := newParser("foo bar")
 		p.expect(lexer.Float)
 
-		require.EqualError(t, p.err, "input.graphql:1 Expected Float, found Name")
+		require.EqualError(t, p.err, "input.graphql:1: Expected Float, found Name")
 	})
 
 	t.Run("expectKeyword error", func(t *testing.T) {
 		p := newParser("foo bar")
 		p.expectKeyword("baz")
 
-		require.EqualError(t, p.err, "input.graphql:1 Expected \"baz\", found Name \"foo\"")
+		require.EqualError(t, p.err, "input.graphql:1: Expected \"baz\", found Name \"foo\"")
 	})
 }
 

--- a/validator/coercevars.go
+++ b/validator/coercevars.go
@@ -1,0 +1,152 @@
+package validator
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/vektah/gqlparser/ast"
+	"github.com/vektah/gqlparser/gqlerror"
+)
+
+// CoerceVariableValues checks the variables for a given operation are valid. mutates variables to include default values where they were not provided
+func CoerceVariableValues(schema *ast.Schema, op *ast.OperationDefinition, variables map[string]interface{}) (map[string]interface{}, *gqlerror.Error) {
+	coercedVars := map[string]interface{}{}
+
+	validator := operationValidator{
+		path:   []interface{}{"variable"},
+		schema: schema,
+	}
+
+	for _, v := range op.VariableDefinitions {
+		validator.path = append(validator.path, v.Variable)
+
+		if !v.Definition.IsInputType() {
+			return nil, gqlerror.ErrorPathf(validator.path, "must an input type")
+		}
+
+		val, hasValue := variables[v.Variable]
+		if !hasValue {
+			if v.DefaultValue != nil {
+				var err error
+				val, err = v.DefaultValue.Value(variables)
+				if err != nil {
+					return nil, gqlerror.WrapPath(validator.path, err)
+				}
+				hasValue = true
+			} else if v.Type.NonNull {
+				return nil, gqlerror.ErrorPathf(validator.path, "must be defined")
+			}
+		}
+
+		rv := reflect.ValueOf(val)
+		if v.Type.NonNull && val == nil {
+			return nil, gqlerror.ErrorPathf(validator.path, "cannot be null")
+		}
+
+		if rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface {
+			rv = rv.Elem()
+		}
+
+		if err := validator.validateVarType(v.Type, rv); err != nil {
+			return nil, err
+		}
+
+		if hasValue {
+			coercedVars[v.Variable] = val
+		}
+
+		validator.path = validator.path[0 : len(validator.path)-1]
+	}
+
+	return coercedVars, nil
+}
+
+type operationValidator struct {
+	path   []interface{}
+	schema *ast.Schema
+}
+
+func (v *operationValidator) validateVarType(typ *ast.Type, val reflect.Value) *gqlerror.Error {
+	if typ.Elem != nil {
+		if val.Kind() != reflect.Slice {
+			return gqlerror.ErrorPathf(v.path, "must be an array")
+		}
+
+		for i := 0; i < val.Len(); i++ {
+			v.path = append(v.path, i)
+			field := val.Index(i)
+
+			fmt.Println(field.Kind(), field.IsNil())
+			if field.Kind() == reflect.Ptr || field.Kind() == reflect.Interface {
+				if typ.Elem.NonNull && field.IsNil() {
+					return gqlerror.ErrorPathf(v.path, "cannot be null")
+				}
+				field = field.Elem()
+			}
+
+			if err := v.validateVarType(typ.Elem, field); err != nil {
+				return err
+			}
+
+			v.path = v.path[0 : len(v.path)-1]
+		}
+
+		return nil
+	}
+
+	def := v.schema.Types[typ.NamedType]
+	if def == nil {
+		panic(fmt.Errorf("missing def for %s", typ.NamedType))
+	}
+
+	switch def.Kind {
+	case ast.Scalar, ast.Enum:
+		// todo scalar coercion, assuming valid for now
+	case ast.InputObject:
+		if val.Kind() != reflect.Map {
+			return gqlerror.ErrorPathf(v.path, "must be a %s", def.Name)
+		}
+
+		// check for unknown fields
+		for _, name := range val.MapKeys() {
+			val.MapIndex(name)
+			fieldDef := def.Fields.ForName(name.String())
+			v.path = append(v.path, name)
+
+			if fieldDef == nil {
+				return gqlerror.ErrorPathf(v.path, "unknown field")
+			}
+			v.path = v.path[0 : len(v.path)-1]
+		}
+
+		for _, fieldDef := range def.Fields {
+			v.path = append(v.path, fieldDef.Name)
+
+			field := val.MapIndex(reflect.ValueOf(fieldDef.Name))
+			if !field.IsValid() {
+				if fieldDef.Type.NonNull {
+					return gqlerror.ErrorPathf(v.path, "must be defined")
+				}
+				continue
+			}
+
+			if field.Kind() == reflect.Ptr || field.Kind() == reflect.Interface {
+				if typ.NonNull && field.IsNil() {
+					return gqlerror.ErrorPathf(v.path, "cannot be null")
+				}
+				field = field.Elem()
+			}
+
+			err := v.validateVarType(fieldDef.Type, field)
+			if err != nil {
+				return err
+			}
+
+			v.path = v.path[0 : len(v.path)-1]
+		}
+	default:
+		panic(fmt.Errorf("unsupported type %s", def.Kind))
+	}
+
+	return nil
+}

--- a/validator/coercevars_test.go
+++ b/validator/coercevars_test.go
@@ -1,0 +1,162 @@
+package validator_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser"
+	"github.com/vektah/gqlparser/ast"
+	"github.com/vektah/gqlparser/validator"
+)
+
+func TestCoerceVars(t *testing.T) {
+	schema := gqlparser.MustLoadSchema(&ast.Source{
+		Name:  "vars.graphql",
+		Input: mustReadFile("./testdata/vars.graphql"),
+	})
+
+	t.Run("undefined variable", func(t *testing.T) {
+		t.Run("without default", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query($id: Int!) { intArg(i: $id) }`)
+			_, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), nil)
+			require.EqualError(t, gerr, "input: variable.id must be defined")
+		})
+
+		t.Run("nil in required value", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query($id: Int!) { intArg(i: $id) }`)
+			_, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"id": nil,
+			})
+			require.EqualError(t, gerr, "input: variable.id cannot be null")
+		})
+
+		t.Run("with default", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query($id: Int! = 1) { intArg(i: $id) }`)
+			vars, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), nil)
+			require.Nil(t, gerr)
+			require.EqualValues(t, 1, vars["id"])
+		})
+
+		t.Run("with union", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query($id: Int! = 1) { intArg(i: $id) }`)
+			vars, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), nil)
+			require.Nil(t, gerr)
+			require.EqualValues(t, 1, vars["id"])
+		})
+	})
+
+	t.Run("input object", func(t *testing.T) {
+		t.Run("non object", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: InputType!) { structArg(i: $var) }`)
+			_, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": "hello",
+			})
+			require.EqualError(t, gerr, "input: variable.var must be a InputType")
+		})
+
+		t.Run("defaults", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: InputType! = {name: "foo"}) { structArg(i: $var) }`)
+			vars, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), nil)
+			require.Nil(t, gerr)
+			require.EqualValues(t, map[string]interface{}{"name": "foo"}, vars["var"])
+		})
+
+		t.Run("valid value", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: InputType!) { structArg(i: $var) }`)
+			vars, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": map[string]interface{}{
+					"name": "foobar",
+				},
+			})
+			require.Nil(t, gerr)
+			require.EqualValues(t, map[string]interface{}{"name": "foobar"}, vars["var"])
+		})
+
+		t.Run("missing required values", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: InputType!) { structArg(i: $var) }`)
+			_, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": map[string]interface{}{},
+			})
+			require.EqualError(t, gerr, "input: variable.var.name must be defined")
+		})
+
+		t.Run("null required field", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: InputType!) { structArg(i: $var) }`)
+			_, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": map[string]interface{}{
+					"name": nil,
+				},
+			})
+			require.EqualError(t, gerr, "input: variable.var.name cannot be null")
+		})
+
+		t.Run("unknown field", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: InputType!) { structArg(i: $var) }`)
+			_, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": map[string]interface{}{
+					"name":    "foobar",
+					"foobard": true,
+				},
+			})
+			require.EqualError(t, gerr, "input: variable.var.foobard unknown field")
+		})
+	})
+
+	t.Run("array", func(t *testing.T) {
+		t.Run("non array", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: [InputType!]) { arrayArg(i: $var) }`)
+			_, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": "hello",
+			})
+			require.EqualError(t, gerr, "input: variable.var must be an array")
+		})
+
+		t.Run("defaults", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: [InputType!] = [{name: "foo"}]) { arrayArg(i: $var) }`)
+			vars, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), nil)
+			require.Nil(t, gerr)
+			require.EqualValues(t, []interface{}{map[string]interface{}{
+				"name": "foo",
+			}}, vars["var"])
+		})
+
+		t.Run("valid value", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: [InputType!]) { arrayArg(i: $var) }`)
+			vars, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": []interface{}{map[string]interface{}{
+					"name": "foo",
+				}},
+			})
+			require.Nil(t, gerr)
+			require.EqualValues(t, []interface{}{map[string]interface{}{
+				"name": "foo",
+			}}, vars["var"])
+		})
+
+		t.Run("null element value", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: [InputType!]) { arrayArg(i: $var) }`)
+			_, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": []interface{}{nil},
+			})
+			require.EqualError(t, gerr, "input: variable.var[0] cannot be null")
+		})
+
+		t.Run("missing required values", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: [InputType!]) { arrayArg(i: $var) }`)
+			_, gerr := validator.CoerceVariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": []interface{}{map[string]interface{}{}},
+			})
+			require.EqualError(t, gerr, "input: variable.var[0].name must be defined")
+		})
+	})
+}
+
+func mustReadFile(name string) string {
+	src, err := ioutil.ReadFile(name)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(src)
+}

--- a/validator/imported_test.go
+++ b/validator/imported_test.go
@@ -52,7 +52,7 @@ func TestValidation(t *testing.T) {
 		schemas = append(schemas, schema)
 	}
 
-	err := filepath.Walk("./imported/spec/", func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk("./", func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() || !strings.HasSuffix(path, ".spec.yml") {
 			return nil
 		}

--- a/validator/testdata/vars.graphql
+++ b/validator/testdata/vars.graphql
@@ -1,0 +1,9 @@
+type Query {
+    intArg(i: Int!): Boolean!
+    structArg(i: InputType!): Boolean!
+    arrayArg(i: [InputType!]): Boolean!
+}
+
+input InputType {
+    name: String!
+}


### PR DESCRIPTION
Validation does not look at variables, so the result of validating a query can be cached.

This PR  implements [variable coercion](http://facebook.github.io/graphql/June2018/#sec-Coercing-Variable-Values)

Follow up PR to add in hooks for scalar coercion hooks.