### PR TITLE
Allow json.Number through var validation

### DIFF
--- a/validator/vars.go
+++ b/validator/vars.go
@@ -112,11 +112,11 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) *gqlerr
 		kind := val.Type().Kind()
 		switch typ.NamedType {
 		case "Int":
-			if kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
+			if kind == reflect.String || kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
 				return nil
 			}
 		case "Float":
-			if kind == reflect.Float32 || kind == reflect.Float64 || kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
+			if kind == reflect.String || kind == reflect.Float32 || kind == reflect.Float64 || kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
 				return nil
 			}
 		case "String":

--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -4,6 +4,8 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"encoding/json"
+
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser"
 	"github.com/vektah/gqlparser/ast"
@@ -187,6 +189,15 @@ func TestValidateVars(t *testing.T) {
 			q := gqlparser.MustLoadQuery(schema, `query foo($var: Int) { optionalIntArg(i: $var) }`)
 			_, gerr := validator.VariableValues(schema, q.Operations.ForName(""), nil)
 			require.Nil(t, gerr)
+		})
+
+		t.Run("Json Number -> Int", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: Int) { optionalIntArg(i: $var) }`)
+			vars, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": json.Number("10"),
+			})
+			require.Nil(t, gerr)
+			require.Equal(t, json.Number("10"), vars["var"])
 		})
 
 		t.Run("Bool -> Int", func(t *testing.T) {


### PR DESCRIPTION
This is needed to correctly represent large ints in variables (parser is fine, but variables come from a json.Decoder)