### PR TITLE
Fix validator for inline fragments with no type conditions

### DIFF
--- a/validator/walk.go
+++ b/validator/walk.go
@@ -246,7 +246,7 @@ func (w *Walker) walkSelection(parentDef *ast.Definition, it ast.Selection) {
 	case *ast.InlineFragment:
 		it.ObjectDefinition = parentDef
 
-		var nextParentDef *ast.Definition
+		nextParentDef := parentDef
 		if it.TypeCondition != "" {
 			nextParentDef = w.Schema.Types[it.TypeCondition]
 		}

--- a/validator/walk_test.go
+++ b/validator/walk_test.go
@@ -29,3 +29,24 @@ func TestWalker(t *testing.T) {
 
 	require.True(t, called)
 }
+
+func TestWalkInlineFragment(t *testing.T) {
+	schema, err := LoadSchema(Prelude, &ast.Source{Input: "type Query { name: String }\n schema { query: Query }"})
+	require.Nil(t, err)
+	query, err := parser.ParseQuery(&ast.Source{Input: "{ ... { name } }"})
+	require.Nil(t, err)
+
+	called := false
+	observers := &Events{}
+	observers.OnField(func(walker *Walker, field *ast.Field) {
+		called = true
+
+		require.Equal(t, "name", field.Name)
+		require.Equal(t, "name", field.Definition.Name)
+		require.Equal(t, "Query", field.ObjectDefinition.Name)
+	})
+
+	Walk(schema, query, observers)
+
+	require.True(t, called)
+}


### PR DESCRIPTION
Prior to this change, the `Definition` and `ObjectDefinition` fields of the `Field` struct were not set on fields that appeared inside an inline fragments with no type condition.