### PR TITLE
better error message for unknown field

### DIFF
--- a/validator/vars.go
+++ b/validator/vars.go
@@ -153,7 +153,7 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) *gqlerr
 			v.path = append(v.path, name)
 
 			if fieldDef == nil {
-				return gqlerror.ErrorPathf(v.path, "unknown field")
+				return gqlerror.ErrorPathf(v.path, "unknown field %s", name.String())
 			}
 			v.path = v.path[0 : len(v.path)-1]
 		}

--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -79,12 +79,12 @@ func TestValidateVars(t *testing.T) {
 			q := gqlparser.MustLoadQuery(schema, `query foo($var: InputType!) { structArg(i: $var) }`)
 			vars, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
 				"var": map[string]interface{}{
-					"name": "foobar",
-					"nullName":nil,
+					"name":     "foobar",
+					"nullName": nil,
 				},
 			})
 			require.Nil(t, gerr)
-			require.EqualValues(t, map[string]interface{}{"name": "foobar","nullName":nil}, vars["var"])
+			require.EqualValues(t, map[string]interface{}{"name": "foobar", "nullName": nil}, vars["var"])
 		})
 
 		t.Run("missing required values", func(t *testing.T) {
@@ -113,7 +113,7 @@ func TestValidateVars(t *testing.T) {
 					"foobard": true,
 				},
 			})
-			require.EqualError(t, gerr, "input: variable.var.foobard unknown field")
+			require.EqualError(t, gerr, "input: variable.var.foobard unknown field foobar")
 		})
 	})
 


### PR DESCRIPTION
@vektah  I ran into this error earlier today and was having trouble figuring which `unknown field` the parser was referring to. I ended up stepping through to code to realize that the parser is upset about the `__typename` field from Apollo. Printing out the name of the unknown field would be useful

On a related note what is the best way to ignore the `__typename` field from Apollo