### PR TITLE
Separate Parsing out from Validation

### DIFF
--- a/parser/schema.go
+++ b/parser/schema.go
@@ -13,6 +13,18 @@ func ParseSchema(source *Source) (*SchemaDocument, *gqlerror.Error) {
 	return p.parseSchemaDocument(), p.err
 }
 
+func ParseSchemas(inputs ...*Source) (*SchemaDocument, *gqlerror.Error) {
+	ast := &SchemaDocument{}
+	for _, input := range inputs {
+		inputAst, err := ParseSchema(input)
+		if err != nil {
+			return nil, err
+		}
+		ast.Merge(inputAst)
+	}
+	return ast, nil
+}
+
 func (p *parser) parseSchemaDocument() *SchemaDocument {
 	var doc SchemaDocument
 	doc.Position = p.peekPos()

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -11,16 +11,14 @@ import (
 )
 
 func LoadSchema(inputs ...*Source) (*Schema, *gqlerror.Error) {
-	ast := &SchemaDocument{}
-	for _, input := range inputs {
-		inputAst, err := parser.ParseSchema(input)
-		if err != nil {
-			return nil, err
-		}
-
-		ast.Merge(inputAst)
+	ast, err := parser.ParseSchemas(inputs...)
+	if err != nil {
+		return nil, err
 	}
+	return ValidateSchemaDocument(ast)
+}
 
+func ValidateSchemaDocument(ast *SchemaDocument) (*Schema, *gqlerror.Error) {
 	schema := Schema{
 		Types:         map[string]*Definition{},
 		Directives:    map[string]*DirectiveDefinition{},


### PR DESCRIPTION
This separates out the parsing step with `ValidateSchemaDocument` and offers a public method to validate a `*ast.SchemaDocument` into a valid `*ast.Schema`.  Also introduces the helper method `ParseSchemas`.