### PR TITLE
Don't quote field names in object value strings

### DIFF
--- a/ast/value.go
+++ b/ast/value.go
@@ -107,7 +107,7 @@ func (v *Value) String() string {
 	case ObjectValue:
 		var val []string
 		for _, elem := range v.Children {
-			val = append(val, strconv.Quote(elem.Name)+":"+elem.Value.String())
+			val = append(val, elem.Name+":"+elem.Value.String())
 		}
 		return "{" + strings.Join(val, ",") + "}"
 	default:

--- a/parser/query_test.yml
+++ b/parser/query_test.yml
@@ -504,4 +504,4 @@ large queries:
                     Value: $b
                 - <Argument>
                     Name: "obj"
-                    Value: {"key":"value","block":"block string uses \"\"\""}
+                    Value: {key:"value",block:"block string uses \"\"\""}


### PR DESCRIPTION
Doing this caused problems when introspecting default values in gqlgen.

For example, say you had this schema:

```
type Query {
  field(arg: Arg! = {argField: 1}): Int
}

input Arg {
  argField: Int
}
```

When introspecting, you'd get back results that looked like this:

```
{
   ...
   "args": [
     {
        name: "arg",
        defaultValue: "{\"argField\": 1}"
        ...
     }
   ]
   ...
```

The quotes around `argField` cause problems because they create invalid GraphQL input literal syntax.