### PR TITLE
Fix to output correct path when validation of variable failed

### DIFF
--- a/validator/vars.go
+++ b/validator/vars.go
@@ -73,12 +73,19 @@ type varValidator struct {
 }
 
 func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) *gqlerror.Error {
+	currentPath := v.path
+	resetPath := func() {
+		v.path = currentPath
+	}
+	defer resetPath()
+
 	if typ.Elem != nil {
 		if val.Kind() != reflect.Slice {
 			return gqlerror.ErrorPathf(v.path, "must be an array")
 		}
 
 		for i := 0; i < val.Len(); i++ {
+			resetPath()
 			v.path = append(v.path, i)
 			field := val.Index(i)
 
@@ -92,8 +99,6 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) *gqlerr
 			if err := v.validateVarType(typ.Elem, field); err != nil {
 				return err
 			}
-
-			v.path = v.path[0 : len(v.path)-1]
 		}
 
 		return nil
@@ -150,15 +155,16 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) *gqlerr
 		for _, name := range val.MapKeys() {
 			val.MapIndex(name)
 			fieldDef := def.Fields.ForName(name.String())
+			resetPath()
 			v.path = append(v.path, name.String())
 
 			if fieldDef == nil {
 				return gqlerror.ErrorPathf(v.path, "unknown field")
 			}
-			v.path = v.path[0 : len(v.path)-1]
 		}
 
 		for _, fieldDef := range def.Fields {
+			resetPath()
 			v.path = append(v.path, fieldDef.Name)
 
 			field := val.MapIndex(reflect.ValueOf(fieldDef.Name))
@@ -184,8 +190,6 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) *gqlerr
 			if err != nil {
 				return err
 			}
-
-			v.path = v.path[0 : len(v.path)-1]
 		}
 	default:
 		panic(fmt.Errorf("unsupported type %s", def.Kind))

--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -163,6 +163,18 @@ func TestValidateVars(t *testing.T) {
 			})
 			require.EqualError(t, gerr, "input: variable.var[0].name must be defined")
 		})
+		t.Run("invalid variable paths", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var1: InputType!, $var2: InputType!) { a:structArg(i: $var1) b:structArg(i: $var2) }`)
+			_, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var1": map[string]interface{}{
+					"name": "foobar",
+				},
+				"var2": map[string]interface{}{
+					"nullName": "foobar",
+				},
+			})
+			require.EqualError(t, gerr, "input: variable.var2.name must be defined")
+		})
 	})
 
 	t.Run("Scalars", func(t *testing.T) {


### PR DESCRIPTION
fixes #73
closes https://github.com/99designs/gqlgen/issues/437

https://facebook.github.io/graphql/draft/#sec-Errors
BTW, Is it correct to output variable errors to `"error"`? 🤔 