### PR TITLE
rewrite overlapping fields can be merged

### DIFF
--- a/validator/error.go
+++ b/validator/error.go
@@ -15,17 +15,19 @@ func Message(msg string, args ...interface{}) ErrorOption {
 	}
 }
 
-func At(position *ast.Position) ErrorOption {
+func At(positions ...*ast.Position) ErrorOption {
 	return func(err *gqlerror.Error) {
-		if position == nil {
-			return
-		}
-		err.Locations = append(err.Locations, gqlerror.Location{
-			Line:   position.Line,
-			Column: position.Column,
-		})
-		if position.Src.Name != "" {
-			err.SetFile(position.Src.Name)
+		for _, position := range positions {
+			if position == nil {
+				return
+			}
+			err.Locations = append(err.Locations, gqlerror.Location{
+				Line:   position.Line,
+				Column: position.Column,
+			})
+			if position.Src.Name != "" {
+				err.SetFile(position.Src.Name)
+			}
 		}
 	}
 }

--- a/validator/fieldmap/fieldmap.go
+++ b/validator/fieldmap/fieldmap.go
@@ -1,0 +1,59 @@
+package fieldmap
+
+import "github.com/vektah/gqlparser/ast"
+
+type Map struct {
+	keys   []string
+	values [][]*Node
+	lookup map[string]int
+}
+
+type Node struct {
+	Field *ast.Field
+	Path  Path
+}
+
+func (m *Map) Push(alias string, node *Node) {
+	// make a copy of the node path
+	pathcopy := make([]interface{}, len(node.Path))
+	for i, v := range node.Path {
+		pathcopy[i] = v
+	}
+	node.Path = pathcopy
+
+	if m.lookup == nil {
+		m.lookup = map[string]int{}
+	}
+
+	if i, ok := m.lookup[alias]; ok {
+		m.values[i] = append(m.values[i], node)
+		return
+	}
+
+	m.lookup[alias] = len(m.keys)
+	m.keys = append(m.keys, alias)
+	m.values = append(m.values, []*Node{node})
+}
+
+func (m *Map) Get(alias string) ([]*Node, bool) {
+	if m.lookup == nil {
+		return nil, false
+	}
+	if i, ok := m.lookup[alias]; ok {
+		return m.values[i], true
+	}
+	return nil, false
+}
+
+func (m *Map) Len() int {
+	return len(m.keys)
+}
+
+func (m *Map) At(i int) (key string, value []*Node) {
+	return m.keys[i], m.values[i]
+}
+func (m *Map) Reset() {
+	m.keys = m.keys[0:0]
+	m.values = m.values[0:0]
+	m.lookup = nil
+}

--- a/validator/fieldmap/fieldmap_test.go
+++ b/validator/fieldmap/fieldmap_test.go
@@ -1,0 +1,77 @@
+package fieldmap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/ast"
+)
+
+func TestFieldMap(t *testing.T) {
+	var m Map
+
+	t.Run("zero wont panic", func(t *testing.T) {
+		f, ok := m.Get("bob")
+		require.False(t, ok)
+		require.Nil(t, f)
+		require.Equal(t, 0, m.Len())
+	})
+
+	m.Push("a.a", &Node{&ast.Field{Name: "0"}, []interface{}{1, "2"}})
+	m.Push("a.b", &Node{&ast.Field{Name: "1"}, []interface{}{2, "1"}})
+	m.Push("a.b", &Node{&ast.Field{Name: "2"}, []interface{}{3, "1"}})
+
+	t.Run("get", func(t *testing.T) {
+		t.Run("fetches values", func(t *testing.T) {
+			f, ok := m.Get("a.a")
+			require.True(t, ok)
+			require.Equal(t, "0", f[0].Field.Name)
+		})
+
+		t.Run("collects duplicates in order", func(t *testing.T) {
+			f, ok := m.Get("a.b")
+			require.True(t, ok)
+			require.Equal(t, "1", f[0].Field.Name)
+			require.Equal(t, "2", f[1].Field.Name)
+		})
+
+		t.Run("returns not found", func(t *testing.T) {
+			f, ok := m.Get("bob")
+			require.False(t, ok)
+			require.Nil(t, f)
+		})
+	})
+
+	t.Run("at", func(t *testing.T) {
+		t.Run("fetches values", func(t *testing.T) {
+			key, value := m.At(0)
+			require.Equal(t, "a.a", key)
+			require.Equal(t, "0", value[0].Field.Name)
+		})
+
+		t.Run("collects duplicates in order", func(t *testing.T) {
+			key, value := m.At(1)
+			require.Equal(t, "a.b", key)
+			require.Equal(t, "1", value[0].Field.Name)
+			require.Equal(t, "2", value[1].Field.Name)
+		})
+
+		t.Run("panics on out of bounds", func(t *testing.T) {
+			require.Panics(t, func() {
+				m.At(100)
+			})
+		})
+	})
+
+	t.Run("len", func(t *testing.T) {
+		require.Equal(t, 2, m.Len())
+	})
+
+	t.Run("reset", func(t *testing.T) {
+		m.Reset()
+		f, ok := m.Get("bob")
+		require.False(t, ok)
+		require.Nil(t, f)
+		require.Equal(t, 0, m.Len())
+	})
+}

--- a/validator/fieldmap/path.go
+++ b/validator/fieldmap/path.go
@@ -1,0 +1,67 @@
+package fieldmap
+
+import (
+	"strings"
+
+	"github.com/vektah/gqlparser/ast"
+)
+
+type Path []interface{}
+
+func (p Path) Equal(other Path) bool {
+	ai := 0
+	bi := 0
+	for {
+		if ai >= len(p) && bi >= len(other) {
+			return true
+		}
+		if ai >= len(p) && bi >= len(other) {
+			return false
+		}
+
+		a := p[ai]
+		b := other[bi]
+
+		fieldA, aIsField := a.(*ast.Field)
+		fieldB, bIsField := b.(*ast.Field)
+
+		if aIsField && bIsField && fieldA.Alias == fieldB.Alias {
+			ai++
+			bi++
+			continue
+		}
+
+		fragA, aIsFrag := a.(*ast.InlineFragment)
+		fragB, bIsFrag := b.(*ast.InlineFragment)
+		if aIsFrag && fragA.TypeCondition == "" {
+			ai++
+			continue
+		}
+
+		if bIsFrag && fragB.TypeCondition == "" {
+			bi++
+			continue
+		}
+
+		if aIsFrag && bIsFrag && fragA.TypeCondition == fragB.TypeCondition {
+			ai++
+			bi++
+			continue
+		}
+
+		return false
+	}
+}
+
+func (p Path) String() string {
+	var parts []string
+	for _, v := range p {
+		switch v := v.(type) {
+		case *ast.Field:
+			parts = append(parts, v.Alias)
+		case *ast.InlineFragment:
+			parts = append(parts, "on "+v.TypeCondition)
+		}
+	}
+	return strings.Join(parts, ".")
+}

--- a/validator/fieldmap/path_test.go
+++ b/validator/fieldmap/path_test.go
@@ -1,0 +1,64 @@
+package fieldmap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/ast"
+)
+
+func TestPath(t *testing.T) {
+	require.True(t, Path{
+		&ast.Field{Alias: "a"},
+		&ast.Field{Alias: "b"},
+	}.Equal(Path{
+		&ast.Field{Alias: "a"},
+		&ast.Field{Alias: "b"},
+	}))
+
+	require.False(t, Path{
+		&ast.Field{Alias: "a"},
+		&ast.Field{Alias: "c"},
+	}.Equal(Path{
+		&ast.Field{Alias: "a"},
+		&ast.Field{Alias: "b"},
+	}))
+
+	require.True(t, Path{
+		&ast.Field{Alias: "a"},
+		&ast.InlineFragment{TypeCondition: ""},
+		&ast.Field{Alias: "b"},
+	}.Equal(Path{
+		&ast.Field{Alias: "a"},
+		&ast.Field{Alias: "b"},
+	}))
+
+	require.True(t, Path{
+		&ast.Field{Alias: "a"},
+		&ast.Field{Alias: "b"},
+	}.Equal(Path{
+		&ast.Field{Alias: "a"},
+		&ast.InlineFragment{TypeCondition: ""},
+		&ast.Field{Alias: "b"},
+	}))
+
+	require.True(t, Path{
+		&ast.Field{Alias: "a"},
+		&ast.InlineFragment{TypeCondition: "dog"},
+		&ast.Field{Alias: "b"},
+	}.Equal(Path{
+		&ast.Field{Alias: "a"},
+		&ast.InlineFragment{TypeCondition: "dog"},
+		&ast.Field{Alias: "b"},
+	}))
+
+	require.False(t, Path{
+		&ast.Field{Alias: "a"},
+		&ast.InlineFragment{TypeCondition: "cat"},
+		&ast.Field{Alias: "b"},
+	}.Equal(Path{
+		&ast.Field{Alias: "a"},
+		&ast.InlineFragment{TypeCondition: "dog"},
+		&ast.Field{Alias: "b"},
+	}))
+}

--- a/validator/imported/deviations.yml
+++ b/validator/imported/deviations.yml
@@ -18,3 +18,6 @@
 
 - rule: 'ValuesOfCorrectType/.*custom scalar.*'
   skip: "Custom scalars are a runtime feature, maybe they dont belong in here?"
+
+- rule: 'OverlappingFieldsCanBeMerged/.*'
+  skip: "We write this rules ourselves because upstream has a crazy implementation and matching their error messages is hard."

--- a/validator/rules/fields_on_correct_type.go
+++ b/validator/rules/fields_on_correct_type.go
@@ -10,7 +10,7 @@ import (
 
 func init() {
 	AddRule("FieldsOnCorrectType", func(observers *Events, addError AddErrFunc) {
-		observers.OnField(func(walker *Walker, field *ast.Field) {
+		observers.OnExitField(func(walker *Walker, field *ast.Field) {
 			if field.ObjectDefinition == nil || field.Definition != nil {
 				return
 			}

--- a/validator/rules/fragments_on_composite_types.go
+++ b/validator/rules/fragments_on_composite_types.go
@@ -9,7 +9,7 @@ import (
 
 func init() {
 	AddRule("FragmentsOnCompositeTypes", func(observers *Events, addError AddErrFunc) {
-		observers.OnInlineFragment(func(walker *Walker, inlineFragment *ast.InlineFragment) {
+		observers.OnExitInlineFragment(func(walker *Walker, inlineFragment *ast.InlineFragment) {
 			fragmentType := walker.Schema.Types[inlineFragment.TypeCondition]
 			if fragmentType == nil || fragmentType.IsCompositeType() {
 				return

--- a/validator/rules/known_argument_names.go
+++ b/validator/rules/known_argument_names.go
@@ -8,7 +8,7 @@ import (
 func init() {
 	AddRule("KnownArgumentNames", func(observers *Events, addError AddErrFunc) {
 		// A GraphQL field is only valid if all supplied arguments are defined by that field.
-		observers.OnField(func(walker *Walker, field *ast.Field) {
+		observers.OnExitField(func(walker *Walker, field *ast.Field) {
 			if field.Definition == nil || field.ObjectDefinition == nil {
 				return
 			}

--- a/validator/rules/known_type_names.go
+++ b/validator/rules/known_type_names.go
@@ -22,7 +22,7 @@ func init() {
 			}
 		})
 
-		observers.OnInlineFragment(func(walker *Walker, inlineFragment *ast.InlineFragment) {
+		observers.OnExitInlineFragment(func(walker *Walker, inlineFragment *ast.InlineFragment) {
 			typedName := inlineFragment.TypeCondition
 			if typedName == "" {
 				return

--- a/validator/rules/overlapping_fields_can_be_merged.go
+++ b/validator/rules/overlapping_fields_can_be_merged.go
@@ -2,556 +2,198 @@ package validator
 
 import (
 	"bytes"
-	"fmt"
-	"reflect"
+	"strings"
 
 	"github.com/vektah/gqlparser/ast"
 	. "github.com/vektah/gqlparser/validator"
+	"github.com/vektah/gqlparser/validator/fieldmap"
 )
 
 func init() {
 
 	AddRule("OverlappingFieldsCanBeMerged", func(observers *Events, addError AddErrFunc) {
-		/**
-		 * Algorithm:
-		 *
-		 * Conflicts occur when two fields exist in a query which will produce the same
-		 * response name, but represent differing values, thus creating a conflict.
-		 * The algorithm below finds all conflicts via making a series of comparisons
-		 * between fields. In order to compare as few fields as possible, this makes
-		 * a series of comparisons "within" sets of fields and "between" sets of fields.
-		 *
-		 * Given any selection set, a collection produces both a set of fields by
-		 * also including all inline fragments, as well as a list of fragments
-		 * referenced by fragment spreads.
-		 *
-		 * A) Each selection set represented in the document first compares "within" its
-		 * collected set of fields, finding any conflicts between every pair of
-		 * overlapping fields.
-		 * Note: This is the *only time* that a the fields "within" a set are compared
-		 * to each other. After this only fields "between" sets are compared.
-		 *
-		 * B) Also, if any fragment is referenced in a selection set, then a
-		 * comparison is made "between" the original set of fields and the
-		 * referenced fragment.
-		 *
-		 * C) Also, if multiple fragments are referenced, then comparisons
-		 * are made "between" each referenced fragment.
-		 *
-		 * D) When comparing "between" a set of fields and a referenced fragment, first
-		 * a comparison is made between each field in the original set of fields and
-		 * each field in the the referenced set of fields.
-		 *
-		 * E) Also, if any fragment is referenced in the referenced selection set,
-		 * then a comparison is made "between" the original set of fields and the
-		 * referenced fragment (recursively referring to step D).
-		 *
-		 * F) When comparing "between" two fragments, first a comparison is made between
-		 * each field in the first referenced set of fields and each field in the the
-		 * second referenced set of fields.
-		 *
-		 * G) Also, any fragments referenced by the first must be compared to the
-		 * second, and any fragments referenced by the second must be compared to the
-		 * first (recursively referring to step F).
-		 *
-		 * H) When comparing two fields, if both have selection sets, then a comparison
-		 * is made "between" both selection sets, first comparing the set of fields in
-		 * the first selection set with the set of fields in the second.
-		 *
-		 * I) Also, if any fragment is referenced in either selection set, then a
-		 * comparison is made "between" the other set of fields and the
-		 * referenced fragment.
-		 *
-		 * J) Also, if two fragments are referenced in both selection sets, then a
-		 * comparison is made "between" the two fragments.
-		 *
-		 */
+		var result fieldmap.Map
+		var keyPath []string
+		var typePath []interface{}
 
-		m := &overlappingFieldsCanBeMergedManager{
-			comparedFragmentPairs: pairSet{data: make(map[string]map[string]bool)},
+		observers.OnEnterField(func(walker *Walker, field *ast.Field) {
+			keyPath = append(keyPath, field.Alias)
+			typePath = append(typePath, field)
+		})
+
+		observers.OnExitField(func(walker *Walker, field *ast.Field) {
+			result.Push(keyStr(keyPath), &fieldmap.Node{Field: field, Path: typePath})
+			keyPath = keyPath[0 : len(keyPath)-1]
+			typePath = typePath[0 : len(typePath)-1]
+		})
+
+		checkOverlappingFields := func() {
+			//fmt.Println()
+			//fmt.Println("All fields:")
+			//fmt.Printf("%-30s %-10s %s \n", "KEY", "ALIAS", "NAME")
+			//for pos := 0; pos < result.Len(); pos++ {
+			//	key, overlappingFields := result.At(pos)
+			//	for _, f := range overlappingFields {
+			//		fmt.Printf("%-30s %-10s %s \n", key, f.Alias, f.Name)
+			//	}
+			//}
+			//fmt.Println()
+
+			for pos := 0; pos < result.Len(); pos++ {
+				key, overlappingFields := result.At(pos)
+
+				// bitset marking which overlapping fields are in conflict
+				// used to dedupe without needing to compare
+				fieldConflicts := make([]bool, len(overlappingFields))
+				var hasConflicts bool
+
+				for i, outer := range overlappingFields {
+					for j := i + 1; j < len(overlappingFields); j++ {
+						inner := overlappingFields[j]
+						//fmt.Println("CMP", i, j, outer, inner)
+
+						if conflicts(outer, inner) {
+							fieldConflicts[i] = true
+							fieldConflicts[j] = true
+							hasConflicts = true
+						}
+					}
+				}
+
+				if hasConflicts {
+					// single pass at the end to grab all the conflicts and build a sensible error message
+					var conflictMsg []string
+					var pos []*ast.Position
+					for i, field := range overlappingFields {
+						if !fieldConflicts[i] {
+							continue
+						}
+						conflictMsg = append(conflictMsg, fieldDescription(field.Field))
+						pos = append(pos, field.Field.Position)
+					}
+
+					addError(
+						Message("Field %s has multiple conflicting definitions:\n    %s", key, strings.Join(conflictMsg, "\n    ")),
+						At(pos...),
+					)
+				}
+			}
+			result.Reset()
 		}
 
+		observers.OnEnterInlineFragment(func(walker *Walker, inlineFragment *ast.InlineFragment) {
+			typePath = append(typePath, inlineFragment)
+		})
+
+		observers.OnExitInlineFragment(func(walker *Walker, inlineFragment *ast.InlineFragment) {
+			typePath = typePath[0 : len(typePath)-1]
+		})
+
 		observers.OnOperation(func(walker *Walker, operation *ast.OperationDefinition) {
-			m.walker = walker
-			conflicts := m.findConflictsWithinSelectionSet(operation.SelectionSet)
-			for _, conflict := range conflicts {
-				conflict.addFieldsConflictMessage(addError)
-			}
+			checkOverlappingFields()
 		})
-		observers.OnField(func(walker *Walker, field *ast.Field) {
-			if walker.CurrentOperation == nil {
-				// When checking both Operation and Fragment, errors are duplicated when processing FragmentDefinition referenced from Operation
-				return
-			}
-			m.walker = walker
-			conflicts := m.findConflictsWithinSelectionSet(field.SelectionSet)
-			for _, conflict := range conflicts {
-				conflict.addFieldsConflictMessage(addError)
-			}
-		})
-		observers.OnInlineFragment(func(walker *Walker, inlineFragment *ast.InlineFragment) {
-			m.walker = walker
-			conflicts := m.findConflictsWithinSelectionSet(inlineFragment.SelectionSet)
-			for _, conflict := range conflicts {
-				conflict.addFieldsConflictMessage(addError)
-			}
-		})
+
 		observers.OnFragment(func(walker *Walker, fragment *ast.FragmentDefinition) {
-			m.walker = walker
-			conflicts := m.findConflictsWithinSelectionSet(fragment.SelectionSet)
-			for _, conflict := range conflicts {
-				conflict.addFieldsConflictMessage(addError)
-			}
+			checkOverlappingFields()
 		})
 	})
 }
 
-type pairSet struct {
-	data map[string]map[string]bool
-}
-
-func (pairSet *pairSet) Add(a *ast.FragmentSpread, b *ast.FragmentSpread, areMutuallyExclusive bool) {
-	add := func(a *ast.FragmentSpread, b *ast.FragmentSpread) {
-		m := pairSet.data[a.Name]
-		if m == nil {
-			m = make(map[string]bool)
-			pairSet.data[a.Name] = m
-		}
-		m[b.Name] = areMutuallyExclusive
-	}
-	add(a, b)
-	add(b, a)
-}
-
-func (pairSet *pairSet) Has(a *ast.FragmentSpread, b *ast.FragmentSpread, areMutuallyExclusive bool) bool {
-	am, ok := pairSet.data[a.Name]
-	if !ok {
-		return false
-	}
-	result, ok := am[b.Name]
-	if !ok {
-		return false
-	}
-
-	// areMutuallyExclusive being false is a superset of being true,
-	// hence if we want to know if this PairSet "has" these two with no
-	// exclusivity, we have to ensure it was added as such.
-	if !areMutuallyExclusive {
-		return !result
-	}
-
-	return true
-}
-
-type sequentialFieldsMap struct {
-	// We can't use map[string][]*ast.Field. because map is not stable...
-	seq  []string
-	data map[string][]*ast.Field
-}
-
-type fieldIterateEntry struct {
-	ResponseName string
-	Fields       []*ast.Field
-}
-
-func (m *sequentialFieldsMap) Push(responseName string, field *ast.Field) {
-	fields, ok := m.data[responseName]
-	if !ok {
-		m.seq = append(m.seq, responseName)
-	}
-	fields = append(fields, field)
-	m.data[responseName] = fields
-}
-
-func (m *sequentialFieldsMap) Get(responseName string) ([]*ast.Field, bool) {
-	fields, ok := m.data[responseName]
-	return fields, ok
-}
-
-func (m *sequentialFieldsMap) Iterator() [][]*ast.Field {
-	fieldsList := make([][]*ast.Field, 0, len(m.seq))
-	for _, responseName := range m.seq {
-		fields := m.data[responseName]
-		fieldsList = append(fieldsList, fields)
-	}
-	return fieldsList
-}
-
-func (m *sequentialFieldsMap) KeyValueIterator() []*fieldIterateEntry {
-	fieldEntriesList := make([]*fieldIterateEntry, 0, len(m.seq))
-	for _, responseName := range m.seq {
-		fields := m.data[responseName]
-		fieldEntriesList = append(fieldEntriesList, &fieldIterateEntry{
-			ResponseName: responseName,
-			Fields:       fields,
-		})
-	}
-	return fieldEntriesList
-}
-
-type conflictMessageContainer struct {
-	Conflicts []*ConflictMessage
-}
-
-type ConflictMessage struct {
-	Message      string
-	ResponseName string
-	Names        []string
-	SubMessage   []*ConflictMessage
-	Position     *ast.Position
-}
-
-func (m *ConflictMessage) String(buf *bytes.Buffer) {
-	if len(m.SubMessage) == 0 {
-		buf.WriteString(m.Message)
-		return
-	}
-
-	for idx, subMessage := range m.SubMessage {
-		buf.WriteString(`subfields "`)
-		buf.WriteString(subMessage.ResponseName)
-		buf.WriteString(`" conflict because `)
-		subMessage.String(buf)
-		if idx != len(m.SubMessage)-1 {
-			buf.WriteString(" and ")
-		}
-	}
-}
-
-func (m *ConflictMessage) addFieldsConflictMessage(addError AddErrFunc) {
+func fieldDescription(field *ast.Field) string {
 	var buf bytes.Buffer
-	m.String(&buf)
-	addError(
-		Message(`Fields "%s" conflict because %s. Use different aliases on the fields to fetch both if this was intentional.`, m.ResponseName, buf.String()),
-		At(m.Position),
-	)
-}
-
-type overlappingFieldsCanBeMergedManager struct {
-	walker *Walker
-
-	// per walker
-	comparedFragmentPairs pairSet
-	// cachedFieldsAndFragmentNames interface{}
-
-	// per selectionSet
-	comparedFragments map[string]bool
-}
-
-func (m *overlappingFieldsCanBeMergedManager) findConflictsWithinSelectionSet(selectionSet ast.SelectionSet) []*ConflictMessage {
-	if len(selectionSet) == 0 {
-		return nil
+	if field.ObjectDefinition != nil {
+		buf.WriteString(field.ObjectDefinition.Name)
+	} else {
+		buf.WriteString("???")
 	}
+	buf.WriteRune('.')
 
-	fieldsMap, fragmentSpreads := getFieldsAndFragmentNames(selectionSet)
+	buf.WriteString(field.Name)
 
-	var conflicts conflictMessageContainer
+	buf.WriteRune('(')
 
-	// (A) Find find all conflicts "within" the fieldMap of this selection set.
-	// Note: this is the *only place* `collectConflictsWithin` is called.
-	m.collectConflictsWithin(&conflicts, fieldsMap)
-
-	m.comparedFragments = make(map[string]bool)
-	for idx, fragmentSpreadA := range fragmentSpreads {
-		// (B) Then collect conflicts between these fieldMap and those represented by
-		// each spread fragment name found.
-		m.collectConflictsBetweenFieldsAndFragment(&conflicts, false, fieldsMap, fragmentSpreadA)
-
-		for _, fragmentSpreadB := range fragmentSpreads[idx+1:] {
-			// (C) Then compare this fragment with all other fragments found in this
-			// selection set to collect conflicts between fragments spread together.
-			// This compares each item in the list of fragment names to every other
-			// item in that same list (except for itself).
-			m.collectConflictsBetweenFragments(&conflicts, false, fragmentSpreadA, fragmentSpreadB)
+	for i, arg := range field.Arguments {
+		if i != 0 {
+			buf.WriteString(", ")
 		}
+		buf.WriteString(arg.Name)
+		buf.WriteString(": ")
+		buf.WriteString(arg.Value.String())
 	}
 
-	return conflicts.Conflicts
-}
+	buf.WriteRune(')')
 
-func (m *overlappingFieldsCanBeMergedManager) collectConflictsBetweenFieldsAndFragment(conflicts *conflictMessageContainer, areMutuallyExclusive bool, fieldsMap *sequentialFieldsMap, fragmentSpread *ast.FragmentSpread) {
-	if m.comparedFragments[fragmentSpread.Name] {
-		return
-	}
-	m.comparedFragments[fragmentSpread.Name] = true
+	for _, dir := range field.Directives {
+		buf.WriteRune('@')
+		buf.WriteString(dir.Name)
 
-	if fragmentSpread.Definition == nil {
-		return
-	}
+		buf.WriteRune('(')
 
-	fieldsMapB, fragmentSpreads := getFieldsAndFragmentNames(fragmentSpread.Definition.SelectionSet)
-
-	// Do not compare a fragment's fieldMap to itself.
-	if reflect.DeepEqual(fieldsMap, fieldsMapB) {
-		return
-	}
-
-	// (D) First collect any conflicts between the provided collection of fields
-	// and the collection of fields represented by the given fragment.
-	m.collectConflictsBetween(conflicts, areMutuallyExclusive, fieldsMap, fieldsMapB)
-
-	// (E) Then collect any conflicts between the provided collection of fields
-	// and any fragment names found in the given fragment.
-	baseFragmentSpread := fragmentSpread
-	for _, fragmentSpread := range fragmentSpreads {
-		if fragmentSpread.Name == baseFragmentSpread.Name {
-			continue
-		}
-		m.collectConflictsBetweenFieldsAndFragment(conflicts, areMutuallyExclusive, fieldsMap, fragmentSpread)
-	}
-}
-
-func (m *overlappingFieldsCanBeMergedManager) collectConflictsBetweenFragments(conflicts *conflictMessageContainer, areMutuallyExclusive bool, fragmentSpreadA *ast.FragmentSpread, fragmentSpreadB *ast.FragmentSpread) {
-
-	var check func(fragmentSpreadA *ast.FragmentSpread, fragmentSpreadB *ast.FragmentSpread)
-	check = func(fragmentSpreadA *ast.FragmentSpread, fragmentSpreadB *ast.FragmentSpread) {
-
-		if fragmentSpreadA.Name == fragmentSpreadB.Name {
-			return
-		}
-
-		if m.comparedFragmentPairs.Has(fragmentSpreadA, fragmentSpreadB, areMutuallyExclusive) {
-			return
-		}
-		m.comparedFragmentPairs.Add(fragmentSpreadA, fragmentSpreadB, areMutuallyExclusive)
-
-		if fragmentSpreadA.Definition == nil {
-			return
-		}
-		if fragmentSpreadB.Definition == nil {
-			return
-		}
-
-		fieldsMapA, fragmentSpreadsA := getFieldsAndFragmentNames(fragmentSpreadA.Definition.SelectionSet)
-		fieldsMapB, fragmentSpreadsB := getFieldsAndFragmentNames(fragmentSpreadB.Definition.SelectionSet)
-
-		// (F) First, collect all conflicts between these two collections of fields
-		// (not including any nested fragments).
-		m.collectConflictsBetween(conflicts, areMutuallyExclusive, fieldsMapA, fieldsMapB)
-
-		// (G) Then collect conflicts between the first fragment and any nested
-		// fragments spread in the second fragment.
-		for _, fragmentSpread := range fragmentSpreadsB {
-			check(fragmentSpreadA, fragmentSpread)
-		}
-		// (G) Then collect conflicts between the second fragment and any nested
-		// fragments spread in the first fragment.
-		for _, fragmentSpread := range fragmentSpreadsA {
-			check(fragmentSpread, fragmentSpreadB)
-		}
-	}
-
-	check(fragmentSpreadA, fragmentSpreadB)
-}
-
-func (m *overlappingFieldsCanBeMergedManager) findConflictsBetweenSubSelectionSets(areMutuallyExclusive bool, selectionSetA ast.SelectionSet, selectionSetB ast.SelectionSet) *conflictMessageContainer {
-	var conflicts conflictMessageContainer
-
-	fieldsMapA, fragmentSpreadsA := getFieldsAndFragmentNames(selectionSetA)
-	fieldsMapB, fragmentSpreadsB := getFieldsAndFragmentNames(selectionSetB)
-
-	// (H) First, collect all conflicts between these two collections of field.
-	m.collectConflictsBetween(&conflicts, areMutuallyExclusive, fieldsMapA, fieldsMapB)
-
-	// (I) Then collect conflicts between the first collection of fields and
-	// those referenced by each fragment name associated with the second.
-	for _, fragmentSpread := range fragmentSpreadsB {
-		m.comparedFragments = make(map[string]bool)
-		m.collectConflictsBetweenFieldsAndFragment(&conflicts, areMutuallyExclusive, fieldsMapA, fragmentSpread)
-	}
-
-	// (I) Then collect conflicts between the second collection of fields and
-	// those referenced by each fragment name associated with the first.
-	for _, fragmentSpread := range fragmentSpreadsA {
-		m.comparedFragments = make(map[string]bool)
-		m.collectConflictsBetweenFieldsAndFragment(&conflicts, areMutuallyExclusive, fieldsMapB, fragmentSpread)
-	}
-
-	// (J) Also collect conflicts between any fragment names by the first and
-	// fragment names by the second. This compares each item in the first set of
-	// names to each item in the second set of names.
-	for _, fragmentSpreadA := range fragmentSpreadsA {
-		for _, fragmentSpreadB := range fragmentSpreadsB {
-			m.collectConflictsBetweenFragments(&conflicts, areMutuallyExclusive, fragmentSpreadA, fragmentSpreadB)
-		}
-	}
-
-	if len(conflicts.Conflicts) == 0 {
-		return nil
-	}
-
-	return &conflicts
-}
-
-func (m *overlappingFieldsCanBeMergedManager) collectConflictsWithin(conflicts *conflictMessageContainer, fieldsMap *sequentialFieldsMap) {
-	for _, fields := range fieldsMap.Iterator() {
-		for idx, fieldA := range fields {
-			for _, fieldB := range fields[idx+1:] {
-				conflict := m.findConflict(false, fieldA, fieldB)
-				if conflict != nil {
-					conflicts.Conflicts = append(conflicts.Conflicts, conflict)
-				}
+		for i, arg := range dir.Arguments {
+			if i != 0 {
+				buf.WriteString(", ")
 			}
+			buf.WriteString(arg.Name)
+			buf.WriteString(": ")
+			buf.WriteString(arg.Value.String())
 		}
+
+		buf.WriteRune(')')
 	}
+
+	buf.WriteRune(' ')
+	if field.Definition != nil {
+		buf.WriteString(field.Definition.Type.String())
+	}
+
+	return buf.String()
 }
 
-func (m *overlappingFieldsCanBeMergedManager) collectConflictsBetween(conflicts *conflictMessageContainer, parentFieldsAreMutuallyExclusive bool, fieldsMapA *sequentialFieldsMap, fieldsMapB *sequentialFieldsMap) {
-	for _, fieldsEntryA := range fieldsMapA.KeyValueIterator() {
-		fieldsB, ok := fieldsMapB.Get(fieldsEntryA.ResponseName)
-		if !ok {
-			continue
-		}
-		for _, fieldA := range fieldsEntryA.Fields {
-			for _, fieldB := range fieldsB {
-				conflict := m.findConflict(parentFieldsAreMutuallyExclusive, fieldA, fieldB)
-				if conflict != nil {
-					conflicts.Conflicts = append(conflicts.Conflicts, conflict)
-				}
-			}
-		}
-	}
-}
-
-func (m *overlappingFieldsCanBeMergedManager) findConflict(parentFieldsAreMutuallyExclusive bool, fieldA *ast.Field, fieldB *ast.Field) *ConflictMessage {
-	if fieldA.Definition == nil || fieldA.ObjectDefinition == nil || fieldB.Definition == nil || fieldB.ObjectDefinition == nil {
-		return nil
+func conflicts(a, b *fieldmap.Node) bool {
+	if a.Field.Definition != nil && b.Field.Definition != nil && !a.Field.Definition.Type.IsCompatible(a.Field.Definition.Type) {
+		return true
 	}
 
-	areMutuallyExclusive := parentFieldsAreMutuallyExclusive
-	if !areMutuallyExclusive {
-		tmp := fieldA.ObjectDefinition.Name != fieldB.ObjectDefinition.Name
-		tmp = tmp && fieldA.ObjectDefinition.Kind == ast.Object
-		tmp = tmp && fieldB.ObjectDefinition.Kind == ast.Object
-		areMutuallyExclusive = tmp
-	}
-
-	fieldNameA := fieldA.Name
-	if fieldA.Alias != "" {
-		fieldNameA = fieldA.Alias
-	}
-
-	if !areMutuallyExclusive {
-		// Two aliases must refer to the same field.
-		if fieldA.Name != fieldB.Name {
-			return &ConflictMessage{
-				ResponseName: fieldNameA,
-				Message:      fmt.Sprintf(`%s and %s are different fields`, fieldA.Name, fieldB.Name),
-				Position:     fieldB.Position,
-			}
-		}
-
-		// Two field calls must have the same arguments.
-		if !sameArguments(fieldA.Arguments, fieldB.Arguments) {
-			return &ConflictMessage{
-				ResponseName: fieldNameA,
-				Message:      "they have differing arguments",
-				Position:     fieldB.Position,
-			}
-		}
-	}
-
-	if doTypesConflict(m.walker, fieldA.Definition.Type, fieldB.Definition.Type) {
-		return &ConflictMessage{
-			ResponseName: fieldNameA,
-			Message:      fmt.Sprintf(`they return conflicting types %s and %s`, fieldA.Definition.Type.String(), fieldB.Definition.Type.String()),
-			Position:     fieldB.Position,
-		}
-	}
-
-	// Collect and compare sub-fields. Use the same "visited fragment names" list
-	// for both collections so fields in a fragment reference are never
-	// compared to themselves.
-	conflicts := m.findConflictsBetweenSubSelectionSets(areMutuallyExclusive, fieldA.SelectionSet, fieldB.SelectionSet)
-	if conflicts == nil {
-		return nil
-	}
-	return &ConflictMessage{
-		ResponseName: fieldNameA,
-		SubMessage:   conflicts.Conflicts,
-		Position:     fieldB.Position,
-	}
-}
-
-func sameArguments(args1 []*ast.Argument, args2 []*ast.Argument) bool {
-	if len(args1) != len(args2) {
+	if !a.Path.Equal(b.Path) {
 		return false
 	}
-	for _, arg1 := range args1 {
-		for _, arg2 := range args2 {
-			if arg1.Name != arg2.Name {
-				return false
-			}
-			if !sameValue(arg1.Value, arg2.Value) {
-				return false
-			}
+
+	if a.Field.Name != b.Field.Name {
+		return true
+	}
+
+	if len(a.Field.Arguments) != len(b.Field.Arguments) {
+		return true
+	}
+
+	for i := 0; i < len(b.Field.Arguments); i++ {
+		if a.Field.Arguments[i].Name != b.Field.Arguments[i].Name {
+			return true
 		}
-	}
-	return true
-}
 
-func sameValue(value1 *ast.Value, value2 *ast.Value) bool {
-	if value1.Kind != value2.Kind {
-		return false
-	}
-	if value1.Raw != value2.Raw {
-		return false
-	}
-	return true
-}
-
-func doTypesConflict(walker *Walker, type1 *ast.Type, type2 *ast.Type) bool {
-	if type1.Elem != nil {
-		if type2.Elem != nil {
-			return doTypesConflict(walker, type1.Elem, type2.Elem)
+		if a.Field.Arguments[i].Value.String() != b.Field.Arguments[i].Value.String() {
+			return true
 		}
-		return true
-	}
-	if type2.Elem != nil {
-		return true
-	}
-	if type1.NonNull && !type2.NonNull {
-		return true
-	}
-	if !type1.NonNull && type2.NonNull {
-		return true
-	}
-
-	t1 := walker.Schema.Types[type1.NamedType]
-	t2 := walker.Schema.Types[type2.NamedType]
-	if (t1.Kind == ast.Scalar || t1.Kind == ast.Enum) && (t2.Kind == ast.Scalar || t2.Kind == ast.Enum) {
-		return t1.Name != t2.Name
 	}
 
 	return false
 }
 
-func getFieldsAndFragmentNames(selectionSet ast.SelectionSet) (*sequentialFieldsMap, []*ast.FragmentSpread) {
-	fieldsMap := sequentialFieldsMap{
-		data: make(map[string][]*ast.Field),
-	}
-	var fragmentSpreads []*ast.FragmentSpread
+func keyStr(path []string) string {
+	var buf bytes.Buffer
 
-	var walk func(selectionSet ast.SelectionSet)
-	walk = func(selectionSet ast.SelectionSet) {
-		for _, selection := range selectionSet {
-			switch selection := selection.(type) {
-			case *ast.Field:
-				responseName := selection.Name
-				if selection.Alias != "" {
-					responseName = selection.Alias
-				}
-				fieldsMap.Push(responseName, selection)
-
-			case *ast.InlineFragment:
-				walk(selection.SelectionSet)
-
-			case *ast.FragmentSpread:
-				fragmentSpreads = append(fragmentSpreads, selection)
-			}
+	for i, v := range path {
+		// skip empty type conditions in inline fragments
+		if v == "on " {
+			continue
 		}
-	}
-	walk(selectionSet)
 
-	return &fieldsMap, fragmentSpreads
+		if i != 0 {
+			buf.WriteByte('.')
+		}
+
+		buf.WriteString(v)
+	}
+
+	return buf.String()
 }

--- a/validator/rules/possible_fragment_spreads.go
+++ b/validator/rules/possible_fragment_spreads.go
@@ -44,7 +44,7 @@ func init() {
 			emitError()
 		}
 
-		observers.OnInlineFragment(func(walker *Walker, inlineFragment *ast.InlineFragment) {
+		observers.OnExitInlineFragment(func(walker *Walker, inlineFragment *ast.InlineFragment) {
 			validate(walker, inlineFragment.ObjectDefinition, inlineFragment.TypeCondition, func() {
 				addError(
 					Message(`Fragment cannot be spread here as objects of type "%s" can never be of type "%s".`, inlineFragment.ObjectDefinition.Name, inlineFragment.TypeCondition),

--- a/validator/rules/provided_required_arguments.go
+++ b/validator/rules/provided_required_arguments.go
@@ -8,7 +8,7 @@ import (
 func init() {
 	AddRule("ProvidedRequiredArguments", func(observers *Events, addError AddErrFunc) {
 
-		observers.OnField(func(walker *Walker, field *ast.Field) {
+		observers.OnExitField(func(walker *Walker, field *ast.Field) {
 			if field.Definition == nil {
 				return
 			}

--- a/validator/rules/scalar_leafs.go
+++ b/validator/rules/scalar_leafs.go
@@ -7,7 +7,7 @@ import (
 
 func init() {
 	AddRule("ScalarLeafs", func(observers *Events, addError AddErrFunc) {
-		observers.OnField(func(walker *Walker, field *ast.Field) {
+		observers.OnExitField(func(walker *Walker, field *ast.Field) {
 			if field.Definition == nil {
 				return
 			}

--- a/validator/rules/unique_argument_names.go
+++ b/validator/rules/unique_argument_names.go
@@ -7,7 +7,7 @@ import (
 
 func init() {
 	AddRule("UniqueArgumentNames", func(observers *Events, addError AddErrFunc) {
-		observers.OnField(func(walker *Walker, field *ast.Field) {
+		observers.OnExitField(func(walker *Walker, field *ast.Field) {
 			checkUniqueArgs(field.Arguments, addError)
 		})
 

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -170,7 +170,7 @@ func validateDirective(schema *Schema, def *DirectiveDefinition) *gqlerror.Error
 func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 	for _, field := range def.Fields {
 		if err := validateName(field.Position, field.Name); err != nil {
-			// now, GraphQL spec doesn't have reserved field name
+			// now, GraphQL spec doesn't have reserved exitField name
 			return err
 		}
 		if err := validateTypeRef(schema, field.Type); err != nil {

--- a/validator/spec/OverlappingFieldsCanBeMerged.spec.yml
+++ b/validator/spec/OverlappingFieldsCanBeMerged.spec.yml
@@ -1,0 +1,847 @@
+- name: unique fields
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment uniqueFields on Dog {
+            name
+            nickname
+          }
+          
+  errors: []
+- name: identical fields
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment mergeIdenticalFields on Dog {
+            name
+            name
+          }
+          
+  errors: []
+- name: identical fields with identical args
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment mergeIdenticalFieldsWithIdenticalArgs on Dog {
+            doesKnowCommand(dogCommand: SIT)
+            doesKnowCommand(dogCommand: SIT)
+          }
+          
+  errors: []
+- name: identical fields with identical directives
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment mergeSameFieldsWithSameDirectives on Dog {
+            name @include(if: true)
+            name @include(if: true)
+          }
+          
+  errors: []
+- name: different args with different aliases
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment differentArgsWithDifferentAliases on Dog {
+            knowsSit: doesKnowCommand(dogCommand: SIT)
+            knowsDown: doesKnowCommand(dogCommand: DOWN)
+          }
+          
+  errors: []
+- name: different directives with different aliases
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment differentDirectivesWithDifferentAliases on Dog {
+            nameIfTrue: name @include(if: true)
+            nameIfFalse: name @include(if: false)
+          }
+          
+  errors: []
+- name: different skip/include directives accepted
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment differentDirectivesWithDifferentAliases on Dog {
+            name @include(if: true)
+            name @include(if: false)
+          }
+          
+  errors: []
+- name: Same aliases with different field targets
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment sameAliasesWithDifferentFieldTargets on Dog {
+            fido: name
+            fido: nickname
+          }
+          
+  errors:
+    - message: |
+        Field fido has multiple conflicting definitions:
+            Dog.name() String
+            Dog.nickname() String
+      locations:
+        - {line: 3, column: 9}
+        - {line: 4, column: 9}
+- name: Same aliases allowed on non-overlapping fields
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment sameAliasesWithDifferentFieldTargets on Pet {
+            ... on Dog {
+              name
+            }
+            ... on Cat {
+              name: nickname
+            }
+          }
+          
+  errors: []
+- name: Alias masking direct field access
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment aliasMaskingDirectFieldAccess on Dog {
+            name: nickname
+            name
+          }
+          
+  errors:
+    - message: |
+        Field name has multiple conflicting definitions:
+            Dog.nickname() String
+            Dog.name() String
+
+      locations:
+        - {line: 3, column: 9}
+        - {line: 4, column: 9}
+- name: 'different args, second adds an argument'
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment conflictingArgs on Dog {
+            doesKnowCommand
+            doesKnowCommand(dogCommand: HEEL)
+          }
+          
+  errors:
+    - message: |
+          Field doesKnowCommand has multiple conflicting definitions:
+              Dog.doesKnowCommand() Boolean
+              Dog.doesKnowCommand(dogCommand: HEEL) Boolean
+      locations:
+        - {line: 3, column: 9}
+        - {line: 4, column: 9}
+- name: 'different args, second missing an argument'
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment conflictingArgs on Dog {
+            doesKnowCommand(dogCommand: SIT)
+            doesKnowCommand
+          }
+          
+  errors:
+    - message: |
+          Field doesKnowCommand has multiple conflicting definitions:
+              Dog.doesKnowCommand(dogCommand: SIT) Boolean
+              Dog.doesKnowCommand() Boolean
+
+      locations:
+        - {line: 3, column: 9}
+        - {line: 4, column: 9}
+- name: conflicting args
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment conflictingArgs on Dog {
+            doesKnowCommand(dogCommand: SIT)
+            doesKnowCommand(dogCommand: HEEL)
+          }
+          
+  errors:
+    - message: |
+          Field doesKnowCommand has multiple conflicting definitions:
+              Dog.doesKnowCommand(dogCommand: SIT) Boolean
+              Dog.doesKnowCommand(dogCommand: HEEL) Boolean
+
+      locations:
+        - {line: 3, column: 9}
+        - {line: 4, column: 9}
+- name: allows different args where no conflict is possible
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment conflictingArgs on Pet {
+            ... on Dog {
+              name(surname: true)
+            }
+            ... on Cat {
+              name
+            }
+          }
+          
+  errors: []
+- name: encounters conflict in fragments
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          {
+            ...A
+            ...B
+          }
+          fragment A on Type {
+            x: a
+          }
+          fragment B on Type {
+            x: b
+          }
+          
+  errors:
+    - message: |
+        Field x has multiple conflicting definitions:
+            Type.a() String
+            Type.b() String
+
+      locations:
+        - {line: 7, column: 9}
+        - {line: 10, column: 9}
+- name: reports each conflict once
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          {
+            f1 {
+              ...A
+              ...B
+            }
+            f2 {
+              ...B
+              ...A
+            }
+            f3 {
+              ...A
+              ...B
+              x: c
+            }
+          }
+          fragment A on Type {
+            x: a
+          }
+          fragment B on Type {
+            x: b
+          }
+          
+  errors:
+    - message: |
+        Field f3.x has multiple conflicting definitions:
+            Type.a() String
+            Type.b() String
+            Type.c() String
+
+      locations:
+        - {line: 18, column: 9}
+        - {line: 21, column: 9}
+        - {line: 14, column: 9}
+    - message: |
+        Field f2.x has multiple conflicting definitions:
+            Type.b() String
+            Type.a() String
+
+      locations:
+        - {line: 21, column: 11}
+        - {line: 18, column: 9}
+    - message: |
+        Field f1.x has multiple conflicting definitions:
+            Type.a() String
+            Type.b() String
+
+      locations:
+        - {line: 18, column: 11}
+        - {line: 21, column: 9}
+- name: deep conflict
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          {
+            field {
+              x: a
+            },
+            field {
+              x: b
+            }
+          }
+          
+  errors:
+    - message: |
+        Field field.x has multiple conflicting definitions:
+            T.a() String
+            T.b() String
+      locations:
+        - {line: 4, column: 9}
+        - {line: 7, column: 11}
+- name: deep conflict with multiple issues
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          {
+            field {
+              x: a
+              y: c
+            },
+            field {
+              x: b
+              y: d
+            }
+          }
+          
+  errors:
+    - message: |
+        Field field.y has multiple conflicting definitions:
+            T.c() String
+            T.d() String
+      locations:
+        - {line: 5, column: 11}
+        - {line: 9, column: 11}
+
+    - message: |
+        Field field.x has multiple conflicting definitions:
+            T.a() String
+            T.b() String
+      locations:
+        - {line: 4, column: 11}
+        - {line: 8, column: 11}
+
+- name: very deep conflict
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          {
+            field {
+              deepField {
+                x: a
+              }
+            },
+            field {
+              deepField {
+                x: b
+              }
+            }
+          }
+          
+  errors:
+    - message: |
+        Field field.deepField.x has multiple conflicting definitions:
+            T.a() String
+            T.b() String
+
+      locations:
+        - {line: 5, column: 13}
+        - {line: 10, column: 13}
+- name: reports deep conflict to nearest common ancestor
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          {
+            field {
+              deepField {
+                x: a
+              }
+              deepField {
+                x: b
+              }
+            },
+            field {
+              deepField {
+                y
+              }
+            }
+          }
+          
+  errors:
+    - message: |
+        Field field.deepField.x has multiple conflicting definitions:
+            T.a() String
+            T.b() String
+
+- name: reports deep conflict to nearest common ancestor in fragments
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          {
+            field {
+              ...F
+            }
+            field {
+              ...F
+            }
+          }
+          fragment F on T {
+            deepField {
+              deeperField {
+                x: a
+              }
+              deeperField {
+                x: b
+              }
+            },
+            deepField {
+              deeperField {
+                y
+              }
+            }
+          }
+          
+  errors:
+    - message: |
+        Field field.deepField.deeperField.x has multiple conflicting definitions:
+            T.a() String
+            T.b() String
+            T.a() String
+            T.b() String
+    - message: |
+        Field deepField.deeperField.x has multiple conflicting definitions:
+            T.a() String
+            T.b() String
+
+
+- name: reports deep conflict in nested fragments
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          {
+            field {
+              ...F
+            }
+            field {
+              ...I
+            }
+          }
+          fragment F on T {
+            x: a
+            ...G
+          }
+          fragment G on T {
+            y: c
+          }
+          fragment I on T {
+            y: d
+            ...J
+          }
+          fragment J on T {
+            x: b
+          }
+          
+  errors:
+    - message: |
+        Field field.y has multiple conflicting definitions:
+            T.c() String
+            T.d() String
+    - message: |
+        Field field.x has multiple conflicting definitions:
+            T.a() String
+            T.b() String
+- name: ignores unknown fragments
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+        
+        {
+          field
+          ...Unknown
+          ...Known
+        }
+        
+        fragment Known on T {
+          field
+          ...OtherUnknown
+        }
+        
+  errors: []
+- name: return types must be unambiguous/conflicting return types which potentially overlap
+  rule: OverlappingFieldsCanBeMerged
+  schema: 1
+  query: |2-
+            
+            {
+              someBox {
+                ...on IntBox {
+                  scalar
+                }
+                ...on NonNullStringBox1 {
+                  scalar
+                }
+              }
+            }
+            
+  errors:
+    - message: Fields "scalar" conflict because they return conflicting types Int and String!. Use different aliases on the fields to fetch both if this was intentional.
+
+- name: return types must be unambiguous/compatible return shapes on different return types
+  rule: OverlappingFieldsCanBeMerged
+  schema: 1
+  query: |2-
+          
+          {
+            someBox {
+              ... on SomeBox {
+                deepBox {
+                  unrelatedField
+                }
+              }
+              ... on StringBox {
+                deepBox {
+                  unrelatedField
+                }
+              }
+            }
+          }
+          
+  errors: []
+- name: return types must be unambiguous/disallows differing return types despite no overlap
+  rule: OverlappingFieldsCanBeMerged
+  schema: 1
+  query: |2-
+            
+            {
+              someBox {
+                ... on IntBox {
+                  scalar
+                }
+                ... on StringBox {
+                  scalar
+                }
+              }
+            }
+            
+  errors:
+    - message: Fields "scalar" conflict because they return conflicting types Int and String. Use different aliases on the fields to fetch both if this was intentional.
+
+- name: return types must be unambiguous/reports correctly when a non-exclusive follows an exclusive
+  rule: OverlappingFieldsCanBeMerged
+  schema: 1
+  query: |2-
+            
+            {
+              someBox {
+                ... on IntBox {
+                  deepBox {
+                    ...X
+                  }
+                }
+              }
+              someBox {
+                ... on StringBox {
+                  deepBox {
+                    ...Y
+                  }
+                }
+              }
+              memoed: someBox {
+                ... on IntBox {
+                  deepBox {
+                    ...X
+                  }
+                }
+              }
+              memoed: someBox {
+                ... on StringBox {
+                  deepBox {
+                    ...Y
+                  }
+                }
+              }
+              other: someBox {
+                ...X
+              }
+              other: someBox {
+                ...Y
+              }
+            }
+            fragment X on SomeBox {
+              scalar
+            }
+            fragment Y on SomeBox {
+              scalar: unrelatedField
+            }
+            
+  errors:
+    - message: Fields "other" conflict because subfields "scalar" conflict because scalar and unrelatedField are different fields. Use different aliases on the fields to fetch both if this was intentional.
+
+- name: return types must be unambiguous/disallows differing return type nullability despite no overlap
+  rule: OverlappingFieldsCanBeMerged
+  schema: 1
+  query: |2-
+            
+            {
+              someBox {
+                ... on NonNullStringBox1 {
+                  scalar
+                }
+                ... on StringBox {
+                  scalar
+                }
+              }
+            }
+            
+  errors:
+    - message: Fields "scalar" conflict because they return conflicting types String! and String. Use different aliases on the fields to fetch both if this was intentional.
+
+- name: return types must be unambiguous/disallows differing return type list despite no overlap
+  rule: OverlappingFieldsCanBeMerged
+  schema: 1
+  query: |2-
+            
+            {
+              someBox {
+                ... on IntBox {
+                  box: listStringBox {
+                    scalar
+                  }
+                }
+                ... on StringBox {
+                  box: stringBox {
+                    scalar
+                  }
+                }
+              }
+            }
+            
+  errors:
+    - message: 'Fields "box" conflict because they return conflicting types [StringBox] and StringBox. Use different aliases on the fields to fetch both if this was intentional.'
+
+- name: return types must be unambiguous/disallows differing return type list despite no overlap
+  rule: OverlappingFieldsCanBeMerged
+  schema: 1
+  query: |2-
+            
+            {
+              someBox {
+                ... on IntBox {
+                  box: stringBox {
+                    scalar
+                  }
+                }
+                ... on StringBox {
+                  box: listStringBox {
+                    scalar
+                  }
+                }
+              }
+            }
+            
+  errors:
+    - message: 'Fields "box" conflict because they return conflicting types StringBox and [StringBox]. Use different aliases on the fields to fetch both if this was intentional.'
+
+- name: return types must be unambiguous/disallows differing subfields
+  rule: OverlappingFieldsCanBeMerged
+  schema: 1
+  query: |2-
+            
+            {
+              someBox {
+                ... on IntBox {
+                  box: stringBox {
+                    val: scalar
+                    val: unrelatedField
+                  }
+                }
+                ... on StringBox {
+                  box: stringBox {
+                    val: scalar
+                  }
+                }
+              }
+            }
+            
+  errors:
+    - message: Fields "val" conflict because scalar and unrelatedField are different fields. Use different aliases on the fields to fetch both if this was intentional.
+
+- name: return types must be unambiguous/disallows differing deep return types despite no overlap
+  rule: OverlappingFieldsCanBeMerged
+  schema: 1
+  query: |2-
+            
+            {
+              someBox {
+                ... on IntBox {
+                  box: stringBox {
+                    scalar
+                  }
+                }
+                ... on StringBox {
+                  box: intBox {
+                    scalar
+                  }
+                }
+              }
+            }
+            
+  errors:
+    - message: Fields "box" conflict because subfields "scalar" conflict because they return conflicting types String and Int. Use different aliases on the fields to fetch both if this was intentional.
+
+- name: return types must be unambiguous/allows non-conflicting overlaping types
+  rule: OverlappingFieldsCanBeMerged
+  schema: 1
+  query: |2-
+            
+            {
+              someBox {
+                ... on IntBox {
+                  scalar: unrelatedField
+                }
+                ... on StringBox {
+                  scalar
+                }
+              }
+            }
+            
+  errors: []
+- name: return types must be unambiguous/same wrapped scalar return types
+  rule: OverlappingFieldsCanBeMerged
+  schema: 1
+  query: |2-
+            
+            {
+              someBox {
+                ...on NonNullStringBox1 {
+                  scalar
+                }
+                ...on NonNullStringBox2 {
+                  scalar
+                }
+              }
+            }
+            
+  errors: []
+- name: return types must be unambiguous/allows inline typeless fragments
+  rule: OverlappingFieldsCanBeMerged
+  schema: 1
+  query: |2-
+            
+            {
+              a
+              ... {
+                a
+              }
+            }
+            
+  errors: []
+- name: return types must be unambiguous/compares deep types including list
+  rule: OverlappingFieldsCanBeMerged
+  schema: 1
+  query: |2-
+            
+            {
+              connection {
+                ...edgeID
+                edges {
+                  node {
+                    id: name
+                  }
+                }
+              }
+            }
+            
+            fragment edgeID on Connection {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+            
+  errors:
+    - message: Fields "edges" conflict because subfields "node" conflict because subfields "id" conflict because name and id are different fields. Use different aliases on the fields to fetch both if this was intentional.
+
+- name: return types must be unambiguous/ignores unknown types
+  rule: OverlappingFieldsCanBeMerged
+  schema: 1
+  query: |2-
+            
+            {
+              someBox {
+                ...on UnknownType {
+                  scalar
+                }
+                ...on NonNullStringBox2 {
+                  scalar
+                }
+              }
+            }
+            
+  errors: []
+- name: return types must be unambiguous/works for field names that are JS keywords
+  rule: OverlappingFieldsCanBeMerged
+  schema: 2
+  query: |2-
+            
+              foo {
+                constructor
+              }
+            }
+  errors: []
+- name: does not infinite loop on recursive fragment
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment fragA on Human { name, relatives { name, ...fragA } }
+          
+  errors: []
+- name: does not infinite loop on immediately recursive fragment
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment fragA on Human { name, ...fragA }
+          
+  errors: []
+- name: does not infinite loop on transitively recursive fragment
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment fragA on Human { name, ...fragB }
+          fragment fragB on Human { name, ...fragC }
+          fragment fragC on Human { name, ...fragA }
+          
+  errors: []
+- name: finds invalid case even with immediately recursive fragment
+  rule: OverlappingFieldsCanBeMerged
+  schema: 0
+  query: |2-
+          
+          fragment sameAliasesWithDifferentFieldTargets on Dog {
+            ...sameAliasesWithDifferentFieldTargets
+            fido: name
+            fido: nickname
+          }
+          
+  errors:
+    - message: Fields "fido" conflict because name and nickname are different fields. Use different aliases on the fields to fetch both if this was intentional.
+

--- a/validator/vars.go
+++ b/validator/vars.go
@@ -159,7 +159,7 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) *gqlerr
 			v.path = append(v.path, name.String())
 
 			if fieldDef == nil {
-				return gqlerror.ErrorPathf(v.path, "unknown field")
+				return gqlerror.ErrorPathf(v.path, "unknown exitField")
 			}
 		}
 
@@ -179,7 +179,7 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) *gqlerr
 				if fieldDef.Type.NonNull && field.IsNil() {
 					return gqlerror.ErrorPathf(v.path, "cannot be null")
 				}
-				//allow null object field and skip it
+				//allow null object exitField and skip it
 				if !fieldDef.Type.NonNull && field.IsNil() {
 					continue
 				}

--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -75,7 +75,7 @@ func TestValidateVars(t *testing.T) {
 			require.EqualValues(t, map[string]interface{}{"name": "foobar"}, vars["var"])
 		})
 
-		t.Run("null object field", func(t *testing.T) {
+		t.Run("null object exitField", func(t *testing.T) {
 			q := gqlparser.MustLoadQuery(schema, `query foo($var: InputType!) { structArg(i: $var) }`)
 			vars, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
 				"var": map[string]interface{}{
@@ -95,7 +95,7 @@ func TestValidateVars(t *testing.T) {
 			require.EqualError(t, gerr, "input: variable.var.name must be defined")
 		})
 
-		t.Run("null required field", func(t *testing.T) {
+		t.Run("null required exitField", func(t *testing.T) {
 			q := gqlparser.MustLoadQuery(schema, `query foo($var: InputType!) { structArg(i: $var) }`)
 			_, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
 				"var": map[string]interface{}{
@@ -116,7 +116,7 @@ func TestValidateVars(t *testing.T) {
 			require.Nil(t, gerr)
 		})
 
-		t.Run("unknown field", func(t *testing.T) {
+		t.Run("unknown exitField", func(t *testing.T) {
 			q := gqlparser.MustLoadQuery(schema, `query foo($var: InputType!) { structArg(i: $var) }`)
 			_, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
 				"var": map[string]interface{}{
@@ -124,7 +124,7 @@ func TestValidateVars(t *testing.T) {
 					"foobard": true,
 				},
 			})
-			require.EqualError(t, gerr, "input: variable.var.foobard unknown field")
+			require.EqualError(t, gerr, "input: variable.var.foobard unknown exitField")
 		})
 	})
 

--- a/validator/walk_test.go
+++ b/validator/walk_test.go
@@ -16,7 +16,7 @@ func TestWalker(t *testing.T) {
 
 	called := false
 	observers := &Events{}
-	observers.OnField(func(walker *Walker, field *ast.Field) {
+	observers.OnExitField(func(walker *Walker, field *ast.Field) {
 		called = true
 
 		require.Equal(t, "name", field.Name)
@@ -38,7 +38,7 @@ func TestWalkInlineFragment(t *testing.T) {
 
 	called := false
 	observers := &Events{}
-	observers.OnField(func(walker *Walker, field *ast.Field) {
+	observers.OnExitField(func(walker *Walker, field *ast.Field) {
 		called = true
 
 		require.Equal(t, "name", field.Name)


### PR DESCRIPTION
# work in progress

Attempt at a much simpler implementation of this rule. Works by collecting all result fields using the walker callbacks and then doing the comparisons at the end.

This also changes the error strings. For example this query
```
fragment conflictingArgs on Dog {
  doesKnowCommand
  doesKnowCommand(dogCommand: HEEL)
}
```
Used to generate an error like this:
```
Fields "doesKnowCommand" conflict because they have differing arguments. Use different aliases on the fields to fetch both if this was intentional.
```
now it reads like this
```
Field doesKnowCommand has multiple conflicting definitions:
    Dog.doesKnowCommand() Boolean
    Dog.doesKnowCommand(dogCommand: HEEL) Boolean
```
This no longer passes the imported test suite, but I think its much more readable and much simpler to implement.

Early feedback is appreciated @vvakame @mathewbyrne 

TODO:
 - [ ] Might have some performance implications. Need to benchmark.