### PR TITLE
Accept single elements as size 1 arrays

### DIFF
--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -145,16 +145,26 @@ func TestValidateVars(t *testing.T) {
 		})
 
 		t.Run("valid value", func(t *testing.T) {
-			q := gqlparser.MustLoadQuery(schema, `query foo($var: [InputType!]) { arrayArg(i: $var) }`)
+			q := gqlparser.MustLoadQuery(schema,
+				`query foo($var1: [InputType!] = [{name: "foo1"}], $var2: [InputType!] = {name: "foo2"}) { a: arrayArg(i: $var1), b: arrayArg(i: $var2) }`)
 			vars, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
-				"var": map[string]interface{}{
+				"var1": []interface{}{map[string]interface{}{
+					"name": "foo",
+				}},
+				"var2": map[string]interface{}{
 					"name": "foo",
 				},
 			})
 			require.Nil(t, gerr)
 			require.EqualValues(t, map[string]interface{}{
-				"name": "foo",
-			}, vars["var"])
+				"var1": []interface{}{map[string]interface{}{
+					"name": "foo",
+				},
+				},
+				"var2": map[string]interface{}{
+					"name": "foo",
+				},
+			}, vars)
 		})
 
 		t.Run("null element value", func(t *testing.T) {


### PR DESCRIPTION
This allows us to send single element values in those inputs defined as array in the schema, parsing them to slices of size 1.

We are trying to transition from another graphql server library to gqlgen, but we can't put it in production since the previous library was permitting this and the change would brake the already integrated clients.

Tests in validator/vars_test.go have been adapted.

I have reproduced some use cases for the schema:

```
type Query {
    arrayArg(i: [InputType!]!): String!
}

input InputType {
    name: String!
    nullName: String
    nullEmbedded: Embedded
}

input Embedded {
    name: String!
}
```
where the result is: 

```go 
func (r *queryResolver) ArrayArg(ctx context.Context, i []InputType) (string, error) {
	return fmt.Sprintf("%v", i), nil
}
```

- valid without variables

```
query 
{
  a: arrayArg(i: {name: "Name"})
  b: arrayArg(i: [{name: "Name"}])
}

result
{
	"data": {
		"a": "[{Name <nil> <nil>}]",
		"b": "[{Name <nil> <nil>}]"
	}
}
```

- valid with variables

```
query ($var1: [InputType!]!, $var2: [InputType!]!) 
{
  a: arrayArg(i: $var1)
  b: arrayArg(i: $var2)
}

query variables
{
	"var1": [
		{
			"name": "Name"
		}
	],
	"var2": {
		"name": "Name"
	}
}

result 
{
	"data": {
		"a": "[{Name <nil> <nil>}]",
		"b": "[{Name <nil> <nil>}]"
	}
}
```

- invalid non variable

```
query
{
  a: arrayArg(i: {nullName: "NullName"})
  b: arrayArg(i: [{nullName: "NullName"}])
  c: arrayArg(i: [null])
  d: arrayArg(i: null)
}

result
{
	"errors": [
		{
			"message": "Field InputType.name of required type String! was not provided.",
			"locations": [
				{
					"line": 2,
					"column": 18
				}
			]
		},
		{
			"message": "Field InputType.name of required type String! was not provided.",
			"locations": [
				{
					"line": 3,
					"column": 19
				}
			]
		},
		{
			"message": "Expected type InputType!, found null.",
			"locations": [
				{
					"line": 4,
					"column": 19
				}
			]
		},
		{
			"message": "Expected type [InputType!]!, found null.",
			"locations": [
				{
					"line": 5,
					"column": 18
				}
			]
		}
	],
	"data": null
}
```

- invalid with array variable 

```
query ($var: [InputType!]!) 
{
  arrayArg(i: $var)
}

query variables
 {
	"var": [
		{
			"nullName": "NullName"
		}
	]
}

result
{
	"errors": [
		{
			"message": "must be defined",
			"path": [
				"variable",
				"var",
				0,
				"name"
			]
		}
	],
	"data": null
} 
```

- invalid with single elem variable

```
query ($var: [InputType!]!) {
  arrayArg(i: $var)
}

query variables
{
	"var": {
		"nullName": "NullName"
	}
}

result
{
	"errors": [
		{
			"message": "must be defined",
			"path": [
				"variable",
				"var",
				0,
				"name"
			]
		}
	],
	"data": null
}
```