### PR TITLE
Fix link in readme pointing to reference impl

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,4 +14,4 @@ Guiding principles:
  - server agnostic: It should be usable by any of the graphql server implementations, and any graphql client tooling.
  - idiomatic & stable api: It should follow go best practices, especially around forwards compatibility.
  - fast: Where it doesnt impact on the above it should be fast. Avoid unnecessary allocs in hot paths.
- - close to reference: Where it doesnt impact on the above, it should stay close to the [graphql/graphql-js](github.com/graphql/graphql-js) reference implementation.
+ - close to reference: Where it doesnt impact on the above, it should stay close to the [graphql/graphql-js](https://github.com/graphql/graphql-js) reference implementation.


### PR DESCRIPTION
The old link was trying to use relative urls, which only work inside of the repo itself.