### PR TITLE
Add documentation to the Source struct

### DIFF
--- a/ast/source.go
+++ b/ast/source.go
@@ -9,8 +9,7 @@ type Source struct {
 	// BuiltIn indicate whether the source is a part of the specification
 	BuiltIn bool
 }
-
-// Position 
+ 
 type Position struct {
 	Start  int     // The starting position, in runes, of this token in the input.
 	End    int     // The end position, in runes, of this token in the input.

--- a/ast/source.go
+++ b/ast/source.go
@@ -1,11 +1,16 @@
 package ast
 
+// Source covers a single *.graphql file
 type Source struct {
+	// Name is the filename of the source
 	Name    string
+	// Input is the actual contents of the source file
 	Input   string
+	// BuiltIn indicate whether the source is a part of the specification
 	BuiltIn bool
 }
 
+// Position 
 type Position struct {
 	Start  int     // The starting position, in runes, of this token in the input.
 	End    int     // The end position, in runes, of this token in the input.


### PR DESCRIPTION
I am a little unsure whether the comment to the `BuiltIn` attribute
is correct, the others should be okay though.