### PR TITLE
Validate Definition Field Types

### DIFF
--- a/validator/schema.go
+++ b/validator/schema.go
@@ -189,8 +189,8 @@ func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 		if typDef == nil {
 			return gqlerror.ErrorPosf(def.Position, "Undefined type %s.", strconv.Quote(typ))
 		}
-		if !isValidKind(typDef.Kind, []DefinitionKind{Object}) {
-			return gqlerror.ErrorPosf(def.Position, "%s type %s must be %s.", def.Kind, strconv.Quote(typ), kindList([]DefinitionKind{Object}))
+		if !isValidKind(typDef.Kind, Object) {
+			return gqlerror.ErrorPosf(def.Position, "%s type %s must be %s.", def.Kind, strconv.Quote(typ), kindList(Object))
 		}
 	}
 
@@ -209,11 +209,10 @@ func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 		if len(def.Fields) == 0 {
 			return gqlerror.ErrorPosf(def.Position, "%s must define one or more fields.", def.Kind)
 		}
-		validKinds := []DefinitionKind{Scalar, Object, Interface, Union, Enum}
 		for _, field := range def.Fields {
 			if typ, ok := schema.Types[field.Type.Name()]; ok {
-				if !isValidKind(typ.Kind, validKinds) {
-					return gqlerror.ErrorPosf(field.Position, "%s field must be one of %s.", def.Kind, kindList(validKinds))
+				if !isValidKind(typ.Kind, Scalar, Object, Interface, Union, Enum) {
+					return gqlerror.ErrorPosf(field.Position, "%s field must be one of %s.", def.Kind, kindList(Scalar, Object, Interface, Union, Enum))
 				}
 			}
 		}
@@ -226,10 +225,9 @@ func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 			return gqlerror.ErrorPosf(def.Position, "%s must define one or more input fields.", def.Kind)
 		}
 		for _, field := range def.Fields {
-			validKinds := []DefinitionKind{Scalar, Enum, InputObject}
 			if typ, ok := schema.Types[field.Type.Name()]; ok {
-				if !isValidKind(typ.Kind, validKinds) {
-					return gqlerror.ErrorPosf(field.Position, "%s field must be one of %s.", def.Kind, kindList(validKinds))
+				if !isValidKind(typ.Kind, Scalar, Enum, InputObject) {
+					return gqlerror.ErrorPosf(field.Position, "%s field must be one of %s.", def.Kind, kindList(Scalar, Enum, InputObject))
 				}
 			}
 		}
@@ -301,7 +299,7 @@ func validateName(pos *Position, name string) *gqlerror.Error {
 	return nil
 }
 
-func isValidKind(kind DefinitionKind, valid []DefinitionKind) bool {
+func isValidKind(kind DefinitionKind, valid ...DefinitionKind) bool {
 	for _, k := range valid {
 		if kind == k {
 			return true
@@ -310,7 +308,7 @@ func isValidKind(kind DefinitionKind, valid []DefinitionKind) bool {
 	return false
 }
 
-func kindList(kinds []DefinitionKind) string {
+func kindList(kinds ...DefinitionKind) string {
 	s := make([]string, len(kinds))
 	for i, k := range kinds {
 		s[i] = string(k)

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -184,6 +184,16 @@ func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 		}
 	}
 
+	for _, typ := range def.Types {
+		typDef := schema.Types[typ]
+		if typDef == nil {
+			return gqlerror.ErrorPosf(def.Position, "Undefined type %s.", strconv.Quote(typ))
+		}
+		if !isValidKind(typDef.Kind, []DefinitionKind{Object}) {
+			return gqlerror.ErrorPosf(def.Position, "%s type %s must be %s.", def.Kind, strconv.Quote(typ), kindList([]DefinitionKind{Object}))
+		}
+	}
+
 	for _, intf := range def.Interfaces {
 		intDef := schema.Types[intf]
 		if intDef == nil {

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -199,6 +199,11 @@ func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 		if len(def.Fields) == 0 {
 			return gqlerror.ErrorPosf(def.Position, "%s must define one or more fields.", def.Kind)
 		}
+		for _, field := range def.Fields {
+			if typ, ok := schema.Types[field.Type.Name()]; ok && typ.Kind == InputObject {
+				return gqlerror.ErrorPosf(field.Position, "%s field must not be an input object.", def.Kind)
+			}
+		}
 	case Enum:
 		if len(def.EnumValues) == 0 {
 			return gqlerror.ErrorPosf(def.Position, "%s must define one or more unique enum values.", def.Kind)

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -176,6 +176,17 @@ inputs:
     error:
       message: 'Name "__FooBar" must not begin with "__", which is reserved by GraphQL introspection.'
       locations: [{line: 1, column: 7}]
+  - name: must not allow input in field
+    input: |
+      input Input {
+        id: ID
+      }
+      type Query {
+        input: Input!
+      }
+    error:
+      message: 'Input types cannot be used as fields'
+      locations: [{line: 5, column: 3}]
 
 enums:
   - name: must define one or more unique enum values

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -98,7 +98,7 @@ object types:
         input: Input!
       }
     error:
-      message: 'OBJECT field must not be an input object.'
+      message: 'OBJECT field must be one of SCALAR, OBJECT, INTERFACE, UNION, ENUM.'
       locations: [{line: 5, column: 3}]
 
 interfaces:
@@ -172,7 +172,7 @@ interfaces:
         input: Input!
       }
     error:
-      message: 'INTERFACE field must not be an input object.'
+      message: 'INTERFACE field must be one of SCALAR, OBJECT, INTERFACE, UNION, ENUM.'
       locations: [{line: 8, column: 3}]
 
 inputs:
@@ -203,6 +203,17 @@ inputs:
     error:
       message: 'Name "__FooBar" must not begin with "__", which is reserved by GraphQL introspection.'
       locations: [{line: 1, column: 7}]
+  - name: fields must be scalar, enum, or input objects
+    input: | 
+      input Foo {
+        bar: Bar!
+      }
+      type Bar {
+        id: ID
+      }
+    error:
+      message: INPUT_OBJECT field must be one of SCALAR, ENUM, INPUT_OBJECT.
+      locations: [{line: 2, column: 3}]
 
 enums:
   - name: must define one or more unique enum values

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -89,6 +89,18 @@ object types:
       message: 'Name "__bar" must not begin with "__", which is reserved by GraphQL introspection.'
       locations: [{line: 2, column: 7}]
 
+  - name: must not allow input object as field type 
+    input: |
+      input Input {
+        id: ID
+      }
+      type Query {
+        input: Input!
+      }
+    error:
+      message: 'OBJECT field must not be an input object.'
+      locations: [{line: 5, column: 3}]
+
 interfaces:
   - name: must exist
     input: |
@@ -148,6 +160,21 @@ interfaces:
       message: 'Name "__FooBar" must not begin with "__", which is reserved by GraphQL introspection.'
       locations: [{line: 1, column: 11}]
 
+  - name: must not allow input object as field type 
+    input: |
+      input Input {
+        id: ID
+      }
+      type Query {
+        foo: Foo!
+      }
+      interface Foo {
+        input: Input!
+      }
+    error:
+      message: 'INTERFACE field must not be an input object.'
+      locations: [{line: 8, column: 3}]
+
 inputs:
   - name: must define one or more input fields
     input: |
@@ -176,17 +203,6 @@ inputs:
     error:
       message: 'Name "__FooBar" must not begin with "__", which is reserved by GraphQL introspection.'
       locations: [{line: 1, column: 7}]
-  - name: must not allow input in field
-    input: |
-      input Input {
-        id: ID
-      }
-      type Query {
-        input: Input!
-      }
-    error:
-      message: 'Input types cannot be used as fields'
-      locations: [{line: 5, column: 3}]
 
 enums:
   - name: must define one or more unique enum values

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -245,6 +245,26 @@ enums:
       message: 'Name "__FooBar" must not begin with "__", which is reserved by GraphQL introspection.'
       locations: [{line: 1, column: 6}]
 
+unions:
+  - name: union types must be defined
+    input: |
+      union Foo = Bar | Baz
+      type Bar {
+        id: ID
+      }
+    error:
+      message: "Undefined type \"Baz\"."
+      locations: [{line: 1, column: 7}]
+  - name: union types must be objects
+    input: |
+      union Foo = Baz
+      interface Baz {
+        id: ID
+      }
+    error:
+      message: "UNION type \"Baz\" must be OBJECT."
+      locations: [{line: 1, column: 7}]
+
 type extensions:
   - name: cannot extend non existant types
     input: |


### PR DESCRIPTION
Reported in https://github.com/99designs/gqlgen/issues/500 — the parser allows input types to be used as object and interface fields.  Also in https://github.com/99designs/gqlgen/issues/513 — gqlgen panics if Unions have an undefined member type.

From the spec:

> A field of an Object type may be a Scalar, Enum, another Object type, an Interface, or a Union. 

For interfaces:

> Fields on a GraphQL interface have the same rules as fields on a GraphQL object; their type can be Scalar, Object, Enum, Interface, or Union, or any wrapping type whose base type is one of those five.

For Inputs:

> A GraphQL Input Object defines a set of input fields; the input fields are either scalars, enums, or other input objects.

For Unions:

> The member types of a Union type must all be Object base types; Scalar, Interface and Union types must not be member types of a Union.

This PR adds schema validation for all of these rules.
