### PR TITLE
Add more interface validation

### DIFF
--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -175,6 +175,106 @@ interfaces:
       message: 'INTERFACE field must be one of SCALAR, OBJECT, INTERFACE, UNION, ENUM.'
       locations: [{line: 8, column: 3}]
 
+  - name: must have all fields from interface
+    input: |
+      type Bar implements BarInterface {
+          someField: Int!
+      }
+
+      interface BarInterface {
+          id: ID!
+      }
+    error:
+      message: 'For Bar to implement BarInterface it must have a field called id.'
+      locations: [{line: 1, column: 6}]
+
+  - name: must have same type of fields
+    input: |
+      type Bar implements BarInterface {
+          id: Int!
+      }
+
+      interface BarInterface {
+          id: ID!
+      }
+    error:
+      message: 'For Bar to implement BarInterface the field id must have type ID!.'
+      locations: [{line: 2, column: 5}]
+
+  - name: must have all required arguments
+    input: |
+      type Bar implements BarInterface {
+          id: ID!
+      }
+
+      interface BarInterface {
+          id(ff: Int!): ID!
+      }
+    error:
+      message: 'For Bar to implement BarInterface the field id must have the same arguments but it is missing ff.'
+      locations: [{line: 2, column: 5}]
+
+  - name: must have same argument types
+    input: |
+      type Bar implements BarInterface {
+          id(ff: ID!): ID!
+      }
+
+      interface BarInterface {
+          id(ff: Int!): ID!
+      }
+    error:
+      message: 'For Bar to implement BarInterface the field id must have the same arguments but ff has the wrong type.'
+      locations: [{line: 2, column: 8}]
+
+  - name: may defined additional nullable arguments
+    input: |
+      type Bar implements BarInterface {
+          id(opt: Int): ID!
+      }
+
+      interface BarInterface {
+          id: ID!
+      }
+
+  - name: may defined additional required arguments with defaults
+    input: |
+      type Bar implements BarInterface {
+          id(opt: Int! = 1): ID!
+      }
+
+      interface BarInterface {
+          id: ID!
+      }
+
+  - name: must not define additional required arguments without defaults
+    input: |
+      type Bar implements BarInterface {
+          id(opt: Int!): ID!
+      }
+
+      interface BarInterface {
+          id: ID!
+      }
+    error:
+      message: 'For Bar to implement BarInterface any additional arguments on id must be optional or have a default value but opt is required.'
+      locations: [{line: 2, column: 8}]
+
+  - name: can have covariant argument types
+    input: |
+      union U = A|B
+
+      type A { name: String }
+      type B { name: String }
+
+      type Bar implements BarInterface {
+          f: A!
+      }
+
+      interface BarInterface {
+          f: U!
+      }
+
 inputs:
   - name: must define one or more input fields
     input: |


### PR DESCRIPTION
Fixes https://github.com/99designs/gqlgen/issues/602

from [the spec](https://facebook.github.io/graphql/June2018/#sec-Objects):
- [x] The object type must include a field of the same name for every field defined in an interface.
   - [x] The object field must be of a type which is equal to or a sub‐type of the interface field (covariant).
      - [x] An object field type is a valid sub‐type if it is equal to (the same type as) the interface field type.
      - [x] An object field type is a valid sub‐type if it is an Object type and the interface field type is either an Interface type or a Union type and the object field type is a possible type of the interface field type.
      - [x] An object field type is a valid sub‐type if it is a List type and the interface field type is also a List type and the list‐item type of the object field type is a valid sub‐type of the list‐item type of the interface field type.
      - [x] An object field type is a valid sub‐type if it is a Non‐Null variant of a valid sub‐type of the interface field type.
   - [x] The object field must include an argument of the same name for every argument defined in the interface field.
      - [x] The object field argument must accept the same type (invariant) as the interface field argument.
   - [x] The object field may include additional arguments not defined in the interface field, but any additional argument must not be required, e.g. must not be of a non‐nullable type.