### PR TITLE
Added support for [Int] to have nil(null) values

### DIFF
--- a/validator/testdata/vars.graphql
+++ b/validator/testdata/vars.graphql
@@ -9,6 +9,9 @@ type Query {
     structArg(i: InputType!): Boolean!
     defaultStructArg(i: InputType! = {name: "foo"}): Boolean!
     arrayArg(i: [InputType!]): Boolean!
+    intArrayArg(i: [Int]): Boolean!
+    stringArrayArg(i: [String]): Boolean!
+    boolArrayArg(i: [Boolean]): Boolean!
 }
 
 input InputType {

--- a/validator/vars.go
+++ b/validator/vars.go
@@ -109,6 +109,11 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) *gqlerr
 		panic(fmt.Errorf("missing def for %s", typ.NamedType))
 	}
 
+	if !typ.NonNull && !val.IsValid() {
+		// If the type is not null and we got a invalid value namely null/nil, then it's valid
+		return nil
+	}
+
 	switch def.Kind {
 	case ast.Enum:
 		kind := val.Type().Kind()

--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -252,6 +252,45 @@ func TestValidateVars(t *testing.T) {
 			require.EqualError(t, gerr, "input: variable.var cannot use bool as Int")
 		})
 	})
+
+	t.Run("Int Array", func(t *testing.T) {
+		t.Run("Array with null", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: [Int]) { intArrayArg(i: $var) }`)
+			a := 1
+			b := 2
+
+			_, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": []*int{&a, &b, nil},
+			})
+			require.Nil(t, gerr)
+		})
+	})
+
+	t.Run("String Array", func(t *testing.T) {
+		t.Run("Array with null", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: [String]) { stringArrayArg(i: $var) }`)
+			a := "1"
+			b := "2"
+
+			_, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": []*string{&a, &b, nil},
+			})
+			require.Nil(t, gerr)
+		})
+	})
+
+	t.Run("Boolean Array", func(t *testing.T) {
+		t.Run("Array with null", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: [Boolean]) { boolArrayArg(i: $var) }`)
+			a := true
+			b := false
+
+			_, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": []*bool{&a, &b, nil},
+			})
+			require.Nil(t, gerr)
+		})
+	})
 }
 
 func mustReadFile(name string) string {


### PR DESCRIPTION
Same for String and Boolean

https://graphql.github.io/graphql-spec/June2018/#sec-Combining-List-and-Non-Null

Looks like the library was crashing when you have `[Int]` type defined and `[1, null]` was sent as a query.

This PR doesn't support all the use cases defined in the spec, but only covers ones with null(nil) values in the array(slice)