### PR TITLE
fix directive formatting

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -315,8 +315,7 @@ func (f *formatter) FormatDirectiveDefinitionList(lists ast.DirectiveDefinitionL
 
 func (f *formatter) FormatDirectiveDefinition(def *ast.DirectiveDefinition) {
 	if !f.emitBuiltin {
-		switch def.Name {
-		case "deprecated", "skip", "include":
+		if def.Position.Src.BuiltIn {
 			return
 		}
 	}
@@ -457,12 +456,15 @@ func (f *formatter) FormatDirectiveList(lists ast.DirectiveList) {
 }
 
 func (f *formatter) FormatDirective(dir *ast.Directive) {
-	f.WriteString("@").WriteWord(dir.Name).NoPadding()
+	f.WriteString("@").WriteWord(dir.Name)
 	f.FormatArgumentList(dir.Arguments)
 }
 
 func (f *formatter) FormatArgumentList(lists ast.ArgumentList) {
-	f.WriteString("(")
+	if len(lists) == 0 {
+		return
+	}
+	f.NoPadding().WriteString("(")
 	for idx, arg := range lists {
 		f.FormatArgument(arg)
 

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -472,7 +472,7 @@ func (f *formatter) FormatArgumentList(lists ast.ArgumentList) {
 			f.NoPadding().WriteWord(",")
 		}
 	}
-	f.WriteString(")")
+	f.WriteString(")").NeedPadding()
 }
 
 func (f *formatter) FormatArgument(arg *ast.Argument) {

--- a/formatter/testdata/baseline/FormatSchema/extensions.graphql
+++ b/formatter/testdata/baseline/FormatSchema/extensions.graphql
@@ -1,13 +1,14 @@
 directive @extends on OBJECT
+directive @key(fields: String!) on OBJECT | INTERFACE
 directive @permission(permission: String!) on FIELD
 type Dog {
 	name: String!
 	owner: Person! @permission(permission: "admin")
 }
-type Person @extends {
+type Person @key(fields: "name") {
 	name: String!
 }
-type Query {
+type Query @extends {
 	dogs: [Dog!]!
 }
 type Subscription {

--- a/formatter/testdata/baseline/FormatSchema/extensions.graphql
+++ b/formatter/testdata/baseline/FormatSchema/extensions.graphql
@@ -1,9 +1,10 @@
+directive @extends on OBJECT
 directive @permission(permission: String!) on FIELD
 type Dog {
 	name: String!
 	owner: Person! @permission(permission: "admin")
 }
-type Person {
+type Person @extends {
 	name: String!
 }
 type Query {

--- a/formatter/testdata/baseline/FormatSchemaDocument/extensions.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/extensions.graphql
@@ -5,6 +5,7 @@ extend schema {
 	subscription: Subscription
 }
 directive @permission(permission: String!) on FIELD
+directive @extends on OBJECT
 type Query {
 	dogs: [Dog!]!
 }
@@ -14,7 +15,7 @@ type Subscription {
 type Dog {
 	name: String!
 }
-type Person {
+type Person @extends {
 	name: String!
 }
 extend type Dog {

--- a/formatter/testdata/baseline/FormatSchemaDocument/extensions.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/extensions.graphql
@@ -6,7 +6,8 @@ extend schema {
 }
 directive @permission(permission: String!) on FIELD
 directive @extends on OBJECT
-type Query {
+directive @key(fields: String!) on OBJECT | INTERFACE
+type Query @extends {
 	dogs: [Dog!]!
 }
 type Subscription {
@@ -15,7 +16,7 @@ type Subscription {
 type Dog {
 	name: String!
 }
-type Person @extends {
+type Person @key(fields: "name") {
 	name: String!
 }
 extend type Dog {

--- a/formatter/testdata/source/schema/extensions.graphql
+++ b/formatter/testdata/source/schema/extensions.graphql
@@ -18,7 +18,7 @@ type Dog {
     name: String!
 }
 
-type Person {
+type Person @extends {
     name: String!
 }
 
@@ -27,3 +27,4 @@ extend type Dog {
 }
 
 directive @permission(permission: String!) on FIELD
+directive @extends on OBJECT

--- a/formatter/testdata/source/schema/extensions.graphql
+++ b/formatter/testdata/source/schema/extensions.graphql
@@ -6,7 +6,7 @@ extend schema {
     subscription: Subscription
 }
 
-type Query {
+type Query @extends {
     dogs: [Dog!]!
 }
 
@@ -18,7 +18,7 @@ type Dog {
     name: String!
 }
 
-type Person @extends {
+type Person @key(fields: "name") {
     name: String!
 }
 
@@ -28,3 +28,4 @@ extend type Dog {
 
 directive @permission(permission: String!) on FIELD
 directive @extends on OBJECT
+directive @key(fields: String!) on OBJECT | INTERFACE

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/vektah/gqlparser
 
+go 1.12
+
 require (
 	github.com/agnivade/levenshtein v1.0.1
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883


### PR DESCRIPTION
The new formatter has a few semi-incorrect behaviors such as: 

```
type User @extends {
...
}
```

"incorrectly" becomes:

```
type User @extends(){
...
}
```

Two issues in this formatter are: there's no space before the `{` and unnecessary (if not incorrect) empty parens. 

This PR fixes that. 

Also, directives that are built-in get printed out no matter what, this PR also fixes this. 