### PR TITLE
Add ForNames method to DirectiveList

### DIFF
--- a/ast/collections.go
+++ b/ast/collections.go
@@ -33,6 +33,16 @@ func (l DirectiveList) ForName(name string) *Directive {
 	return nil
 }
 
+func (l DirectiveList) ForNames(name string) []*Directive {
+	resp := []*Directive{}
+	for _, it := range l {
+		if it.Name == name {
+			resp = append(resp, it)
+		}
+	}
+	return resp
+}
+
 type OperationList []*OperationDefinition
 
 func (l OperationList) ForName(name string) *OperationDefinition {


### PR DESCRIPTION
Directives can be repeated multiple times for a type, such as `@key(...) @key(...)` 

This method makes it explicit that for one given name, you can get multiple directives. 