### PR TITLE
Fix ordering error in formatter.FormatDefinition

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -383,14 +383,14 @@ func (f *formatter) FormatDefinition(def *ast.Definition, extend bool) {
 		f.WriteWord("input").WriteWord(def.Name)
 	}
 
+	if len(def.Interfaces) != 0 {
+		f.WriteWord("implements").WriteWord(strings.Join(def.Interfaces, ", "))
+	}
+
 	f.FormatDirectiveList(def.Directives)
 
 	if len(def.Types) != 0 {
 		f.WriteWord("=").WriteWord(strings.Join(def.Types, " | "))
-	}
-
-	if len(def.Interfaces) != 0 {
-		f.WriteWord("implements").WriteWord(strings.Join(def.Interfaces, ", "))
 	}
 
 	f.FormatFieldList(def.Fields)

--- a/formatter/testdata/baseline/FormatSchema/directive_locations.graphql
+++ b/formatter/testdata/baseline/FormatSchema/directive_locations.graphql
@@ -1,0 +1,13 @@
+directive @foo on OBJECT | UNION | ENUM
+enum ConnectionStatus @foo {
+	ONLINE
+	OFFLINE
+	ERROR
+}
+interface Named {
+	name: String!
+}
+type Person implements Named @foo {
+	name: String!
+}
+union PersonUnion @foo = Person

--- a/formatter/testdata/baseline/FormatSchemaDocument/directive_locations.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/directive_locations.graphql
@@ -1,0 +1,13 @@
+directive @foo on OBJECT | UNION | ENUM
+interface Named {
+	name: String!
+}
+type Person implements Named @foo {
+	name: String!
+}
+enum ConnectionStatus @foo {
+	ONLINE
+	OFFLINE
+	ERROR
+}
+union PersonUnion @foo = Person

--- a/formatter/testdata/source/schema/directive_locations.graphql
+++ b/formatter/testdata/source/schema/directive_locations.graphql
@@ -1,0 +1,13 @@
+directive @foo on OBJECT | UNION | ENUM
+interface Named {
+	name: String!
+}
+type Person implements Named @foo {
+	name: String!
+}
+enum ConnectionStatus @foo {
+	ONLINE
+	OFFLINE
+	ERROR
+}
+union PersonUnion @foo = Person


### PR DESCRIPTION
Small bugfix: the formatter was generating incorrect output for objects that have both an implemented interface and a directive attached.