### PR TITLE
Allow extending types that haven't been declared

### DIFF
--- a/validator/schema.go
+++ b/validator/schema.go
@@ -37,7 +37,12 @@ func ValidateSchemaDocument(ast *SchemaDocument) (*Schema, *gqlerror.Error) {
 	for _, ext := range ast.Extensions {
 		def := schema.Types[ext.Name]
 		if def == nil {
-			return nil, gqlerror.ErrorPosf(ext.Position, "Cannot extend type %s because it does not exist.", ext.Name)
+			schema.Types[ext.Name] = &Definition{
+				Kind:        ext.Kind,
+				Name:        ext.Name,
+				Position: ext.Position,
+			}
+			def = schema.Types[ext.Name]
 		}
 
 		if def.Kind != ext.Kind {

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -419,14 +419,12 @@ unions:
       locations: [{line: 1, column: 7}]
 
 type extensions:
-  - name: cannot extend non existant types
+  - name: can extend non existant types
     input: |
       extend type A {
         name: String
       }
-    error:
-      message: "Cannot extend type A because it does not exist."
-      locations: [{line: 1, column: 13}]
+
 
   - name: cannot extend incorret type existant types
     input: |


### PR DESCRIPTION
This comes in handy for apollo federation, and generatlly when decomposing schema down into small files.


eg when defining user.schema you might have:
```
extend Query {
   user(id: ID!): User
}

type User {
   id: ID!
   name: String!
}
```

If your whole app is architected like that then you don't have any file that should own the root query/mutation/schema types, which would be [empty anyway](https://github.com/99designs/gqlgen/issues/630). Allowing them to be created on the first extension removes this little wrinkle.
