### PR TITLE
Fix wrong validation on input field with default value

### DIFF
--- a/validator/testdata/vars.graphql
+++ b/validator/testdata/vars.graphql
@@ -19,6 +19,7 @@ input InputType {
     nullName: String
     nullEmbedded: Embedded
     enum: Enum
+    defaultName: String! = "defaultFoo"
 }
 
 input Embedded {

--- a/validator/vars.go
+++ b/validator/vars.go
@@ -185,6 +185,13 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) *gqlerr
 			field := val.MapIndex(reflect.ValueOf(fieldDef.Name))
 			if !field.IsValid() {
 				if fieldDef.Type.NonNull {
+					if fieldDef.DefaultValue != nil {
+						var err error
+						_, err = fieldDef.DefaultValue.Value(nil)
+						if err == nil {
+							continue
+						}
+					}
 					return gqlerror.ErrorPathf(v.path, "must be defined")
 				}
 				continue


### PR DESCRIPTION
Avoid `must be defined` error on an input field having a default value defined in the schema:

```
type Query {
    structArg(i: InputType!): Boolean!
}
input InputType {
    name: String!
    defaultName: String! = "defaultFoo"
}
```
With variables:
```
{
  "var": {
     "name": "foo"
  }
}
```

**Before**:
Error received: `input: variable.defaultName must be defined`

**After**:
No more errors received, this is the expected behavior because a default value is defined in the schema.

