### PR TITLE
Combine two dict entries with the same name.

### DIFF
--- a/parser/schema_test.yml
+++ b/parser/schema_test.yml
@@ -214,53 +214,6 @@ type extensions:
       message: Unexpected String "Description"
       locations: [{ line: 1, column: 9 }]
 
-schema definition:
-  - name: simple
-    input: |
-      schema {
-        query: Query
-      }
-    ast: |
-      <SchemaDocument>
-        Schema: [SchemaDefinition]
-        - <SchemaDefinition>
-            OperationTypes: [OperationTypeDefinition]
-            - <OperationTypeDefinition>
-                Operation: Operation("query")
-                Type: "Query"
-
-schema extensions:
-  - name: simple
-    input: |
-       extend schema {
-         mutation: Mutation
-       }
-    ast: |
-      <SchemaDocument>
-        SchemaExtension: [SchemaDefinition]
-        - <SchemaDefinition>
-            OperationTypes: [OperationTypeDefinition]
-            - <OperationTypeDefinition>
-                Operation: Operation("mutation")
-                Type: "Mutation"
-
-  - name: directive only
-    input: "extend schema @directive"
-    ast: |
-      <SchemaDocument>
-        SchemaExtension: [SchemaDefinition]
-        - <SchemaDefinition>
-            Directives: [Directive]
-            - <Directive>
-                Name: "directive"
-
-  - name: without anything errors
-    input: "extend schema"
-    error:
-      message: "Unexpected <EOF>"
-      locations: [{ line: 1, column: 14}]
-
-type extensions:
   - name: all can have directives
     input: |
       extend scalar Foo @deprecated
@@ -309,6 +262,51 @@ type extensions:
             - <Directive>
                 Name: "deprecated"
 
+schema definition:
+  - name: simple
+    input: |
+      schema {
+        query: Query
+      }
+    ast: |
+      <SchemaDocument>
+        Schema: [SchemaDefinition]
+        - <SchemaDefinition>
+            OperationTypes: [OperationTypeDefinition]
+            - <OperationTypeDefinition>
+                Operation: Operation("query")
+                Type: "Query"
+
+schema extensions:
+  - name: simple
+    input: |
+       extend schema {
+         mutation: Mutation
+       }
+    ast: |
+      <SchemaDocument>
+        SchemaExtension: [SchemaDefinition]
+        - <SchemaDefinition>
+            OperationTypes: [OperationTypeDefinition]
+            - <OperationTypeDefinition>
+                Operation: Operation("mutation")
+                Type: "Mutation"
+
+  - name: directive only
+    input: "extend schema @directive"
+    ast: |
+      <SchemaDocument>
+        SchemaExtension: [SchemaDefinition]
+        - <SchemaDefinition>
+            Directives: [Directive]
+            - <Directive>
+                Name: "directive"
+
+  - name: without anything errors
+    input: "extend schema"
+    error:
+      message: "Unexpected <EOF>"
+      locations: [{ line: 1, column: 14}]
 
 inheritance:
   - name: single


### PR DESCRIPTION
"schema extensions" was specified twice!  As a result, only the second
one was actually being tested, the first one was being ignored.

Tested by running `go test ./...`