### PR TITLE
improve formatting of argument lists descriptions

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -288,7 +288,10 @@ func (f *formatter) FormatArgumentDefinitionList(lists ast.ArgumentDefinitionLis
 }
 
 func (f *formatter) FormatArgumentDefinition(def *ast.ArgumentDefinition) {
-	f.WriteDescription(def.Description)
+	if def.Description != "" {
+		f.WriteNewline().IncrementIndent()
+		f.WriteDescription(def.Description)
+	}
 
 	f.WriteWord(def.Name).NoPadding().WriteString(":").NeedPadding()
 	f.FormatType(def.Type)
@@ -296,6 +299,11 @@ func (f *formatter) FormatArgumentDefinition(def *ast.ArgumentDefinition) {
 	if def.DefaultValue != nil {
 		f.WriteWord("=")
 		f.FormatValue(def.DefaultValue)
+	}
+
+	if def.Description != "" {
+		f.DecrementIndent()
+		f.WriteNewline()
 	}
 }
 

--- a/formatter/testdata/baseline/FormatSchema/schema.graphql
+++ b/formatter/testdata/baseline/FormatSchema/schema.graphql
@@ -5,10 +5,46 @@ schema {
 }
 type TopMutation {
 	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
 }
 type TopQuery {
 	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
 }
 type TopSubscription {
 	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
 }

--- a/formatter/testdata/baseline/FormatSchemaDocument/schema.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/schema.graphql
@@ -3,12 +3,48 @@ schema {
 	mutation: TopMutation
 	subscription: TopSubscription
 }
-type TopQuery {
-	noop: Boolean
-}
 type TopMutation {
 	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
+}
+type TopQuery {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
 }
 type TopSubscription {
 	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
 }

--- a/formatter/testdata/source/schema/schema.graphql
+++ b/formatter/testdata/source/schema/schema.graphql
@@ -1,17 +1,48 @@
 schema {
-    query: TopQuery
-    mutation: TopMutation
-    subscription: TopSubscription
-}
-
-type TopQuery {
-    noop: Boolean
+	query: TopQuery
+	mutation: TopMutation
+	subscription: TopSubscription
 }
 
 type TopMutation {
     noop: Boolean
+    noop2("""
+      noop2 foo bar
+      """
+      arg: String
+    ): Boolean
+    noop3("noop3 foo bar"
+      arg: String
+    ): Boolean
+}
+
+type TopQuery {
+      noop: Boolean
+
+      noop2("""
+        noop2 foo bar
+        """
+        arg: String
+      ): Boolean
+
+      noop3(
+        "noop3 foo bar"
+        arg: String
+      ): Boolean
 }
 
 type TopSubscription {
-    noop: Boolean
+      noop: Boolean
+
+      noop2(
+        """
+        noop2 foo bar
+        """
+        arg: String
+      ): Boolean
+
+      noop3(
+        "noop3 foo bar"
+        arg: String
+      ): Boolean
 }


### PR DESCRIPTION
This change improves the readability of the description of arguments.

Before:
```gql
noop2("""
noop2 foo bar
"""
arg: String): Boolean
```

After:
```gql
noop2(
  """
  noop2 foo bar
  """
  arg: String
): Boolean
```

Also, Thank you for gqlgen and for this library. ✋ 5️⃣ 