### PR TITLE
Fix directive argument Validation

### DIFF
--- a/ast/definition.go
+++ b/ast/definition.go
@@ -14,7 +14,7 @@ const (
 // ObjectDefinition is the core type definition object, it includes all of the definable types
 // but does *not* cover schema or directives.
 //
-// @vektah: Javascript implementation has different types for all of these, but they are
+// @dgraph-io: Javascript implementation has different types for all of these, but they are
 // more similar than different and don't define any behaviour. I think this style of
 // "some hot" struct works better, at least for go.
 //

--- a/ast/document_test.go
+++ b/ast/document_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	. "github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/parser"
+	. "github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/parser"
 )
 
 func TestQueryDocMethods(t *testing.T) {

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/vektah/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/ast"
 )
 
 type Formatter interface {
@@ -523,7 +523,7 @@ func (f *formatter) FormatVariableDefinition(def *ast.VariableDefinition) {
 		f.FormatValue(def.DefaultValue)
 	}
 
-	// TODO https://github.com/vektah/gqlparser/issues/102
+	// TODO https://github.com/dgraph-io/gqlparser/issues/102
 	//   VariableDefinition : Variable : Type DefaultValue? Directives[Const]?
 }
 

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -10,10 +10,10 @@ import (
 	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vektah/gqlparser"
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/formatter"
-	"github.com/vektah/gqlparser/parser"
+	"github.com/dgraph-io/gqlparser"
+	"github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/formatter"
+	"github.com/dgraph-io/gqlparser/parser"
 )
 
 var update = flag.Bool("u", false, "update golden files")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vektah/gqlparser
+module github.com/dgraph-io/gqlparser
 
 go 1.12
 

--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/vektah/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/ast"
 )
 
 // Error is the standard graphql error type described in https://facebook.github.io/graphql/draft/#sec-Errors

--- a/gqlparser.go
+++ b/gqlparser.go
@@ -1,11 +1,11 @@
 package gqlparser
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/gqlerror"
-	"github.com/vektah/gqlparser/parser"
-	"github.com/vektah/gqlparser/validator"
-	_ "github.com/vektah/gqlparser/validator/rules"
+	"github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/gqlerror"
+	"github.com/dgraph-io/gqlparser/parser"
+	"github.com/dgraph-io/gqlparser/validator"
+	_ "github.com/dgraph-io/gqlparser/validator/rules"
 )
 
 func LoadSchema(str ...*ast.Source) (*ast.Schema, *gqlerror.Error) {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"unicode/utf8"
 
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/gqlerror"
+	"github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/gqlerror"
 )
 
 // Lexer turns graphql request and schema strings into tokens

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -3,8 +3,8 @@ package lexer
 import (
 	"testing"
 
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/parser/testrunner"
+	"github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/parser/testrunner"
 )
 
 func TestLexer(t *testing.T) {

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -3,7 +3,7 @@ package lexer
 import (
 	"strconv"
 
-	"github.com/vektah/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/ast"
 )
 
 const (

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -3,9 +3,9 @@ package parser
 import (
 	"strconv"
 
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/gqlerror"
-	"github.com/vektah/gqlparser/lexer"
+	"github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/gqlerror"
+	"github.com/dgraph-io/gqlparser/lexer"
 )
 
 type parser struct {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/lexer"
+	"github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/lexer"
 )
 
 func TestParserUtils(t *testing.T) {

--- a/parser/query.go
+++ b/parser/query.go
@@ -1,10 +1,10 @@
 package parser
 
 import (
-	"github.com/vektah/gqlparser/gqlerror"
-	"github.com/vektah/gqlparser/lexer"
+	"github.com/dgraph-io/gqlparser/gqlerror"
+	"github.com/dgraph-io/gqlparser/lexer"
 
-	. "github.com/vektah/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/ast"
 )
 
 func ParseQuery(source *Source) (*QueryDocument, *gqlerror.Error) {

--- a/parser/query_test.go
+++ b/parser/query_test.go
@@ -3,8 +3,8 @@ package parser
 import (
 	"testing"
 
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/parser/testrunner"
+	"github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/parser/testrunner"
 )
 
 func TestQueryDocument(t *testing.T) {

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -1,9 +1,9 @@
 package parser
 
 import (
-	. "github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/gqlerror"
-	"github.com/vektah/gqlparser/lexer"
+	. "github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/gqlerror"
+	"github.com/dgraph-io/gqlparser/lexer"
 )
 
 func ParseSchema(source *Source) (*SchemaDocument, *gqlerror.Error) {

--- a/parser/schema_test.go
+++ b/parser/schema_test.go
@@ -3,8 +3,8 @@ package parser
 import (
 	"testing"
 
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/parser/testrunner"
+	"github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/parser/testrunner"
 )
 
 func TestSchemaDocument(t *testing.T) {

--- a/parser/testrunner/runner.go
+++ b/parser/testrunner/runner.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/andreyvit/diff"
-	"github.com/vektah/gqlparser/gqlerror"
+	"github.com/dgraph-io/gqlparser/gqlerror"
 	"gopkg.in/yaml.v2"
 )
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-gqlparser [![CircleCI](https://badgen.net/circleci/github/vektah/gqlparser/master)](https://circleci.com/gh/vektah/gqlparser) [![Go Report Card](https://goreportcard.com/badge/github.com/vektah/gqlparser)](https://goreportcard.com/report/github.com/vektah/gqlparser) [![Coverage Status](https://badgen.net/coveralls/c/github/vektah/gqlparser)](https://coveralls.io/github/vektah/gqlparser?branch=master)
+gqlparser [![CircleCI](https://badgen.net/circleci/github/dgraph-io/gqlparser/master)](https://circleci.com/gh/dgraph-io/gqlparser) [![Go Report Card](https://goreportcard.com/badge/github.com/dgraph-io/gqlparser)](https://goreportcard.com/report/github.com/dgraph-io/gqlparser) [![Coverage Status](https://badgen.net/coveralls/c/github/dgraph-io/gqlparser)](https://coveralls.io/github/dgraph-io/gqlparser?branch=master)
 ===
 
 This is a parser for graphql, written to mirror the graphql-js reference implementation as closely while remaining idiomatic and easy to use.

--- a/validator/error.go
+++ b/validator/error.go
@@ -3,8 +3,8 @@ package validator
 import (
 	"fmt"
 
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/gqlerror"
+	"github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/gqlerror"
 )
 
 type ErrorOption func(err *gqlerror.Error)

--- a/validator/imported_test.go
+++ b/validator/imported_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/vektah/gqlparser"
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/gqlerror"
+	"github.com/dgraph-io/gqlparser"
+	"github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/gqlerror"
 	"gopkg.in/yaml.v2"
 )
 

--- a/validator/prelude.go
+++ b/validator/prelude.go
@@ -1,6 +1,6 @@
 package validator
 
-import "github.com/vektah/gqlparser/ast"
+import "github.com/dgraph-io/gqlparser/ast"
 
 var Prelude = &ast.Source{
 	Name:    "prelude.graphql",

--- a/validator/rules/fields_on_correct_type.go
+++ b/validator/rules/fields_on_correct_type.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/fragments_on_composite_types.go
+++ b/validator/rules/fragments_on_composite_types.go
@@ -3,8 +3,8 @@ package validator
 import (
 	"fmt"
 
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/known_argument_names.go
+++ b/validator/rules/known_argument_names.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/known_directives.go
+++ b/validator/rules/known_directives.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/known_fragment_names.go
+++ b/validator/rules/known_fragment_names.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/known_type_names.go
+++ b/validator/rules/known_type_names.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/lone_anonymous_operation.go
+++ b/validator/rules/lone_anonymous_operation.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/no_fragment_cycles.go
+++ b/validator/rules/no_fragment_cycles.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/no_undefined_variables.go
+++ b/validator/rules/no_undefined_variables.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/no_unused_fragments.go
+++ b/validator/rules/no_unused_fragments.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/no_unused_variables.go
+++ b/validator/rules/no_unused_variables.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/overlapping_fields_can_be_merged.go
+++ b/validator/rules/overlapping_fields_can_be_merged.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/possible_fragment_spreads.go
+++ b/validator/rules/possible_fragment_spreads.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/provided_required_arguments.go
+++ b/validator/rules/provided_required_arguments.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/scalar_leafs.go
+++ b/validator/rules/scalar_leafs.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/single_field_subscriptions.go
+++ b/validator/rules/single_field_subscriptions.go
@@ -3,8 +3,8 @@ package validator
 import (
 	"strconv"
 
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/unique_argument_names.go
+++ b/validator/rules/unique_argument_names.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/unique_directives_per_location.go
+++ b/validator/rules/unique_directives_per_location.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/unique_fragment_names.go
+++ b/validator/rules/unique_fragment_names.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/unique_input_field_names.go
+++ b/validator/rules/unique_input_field_names.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/unique_operation_names.go
+++ b/validator/rules/unique_operation_names.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/unique_variable_names.go
+++ b/validator/rules/unique_variable_names.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/values_of_correct_type.go
+++ b/validator/rules/values_of_correct_type.go
@@ -3,8 +3,8 @@ package validator
 import (
 	"fmt"
 
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/variables_are_input_types.go
+++ b/validator/rules/variables_are_input_types.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/rules/variables_in_allowed_position.go
+++ b/validator/rules/variables_in_allowed_position.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"github.com/vektah/gqlparser/ast"
-	. "github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser/ast"
+	. "github.com/dgraph-io/gqlparser/validator"
 )
 
 func init() {

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"strings"
 
-	. "github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/gqlerror"
-	"github.com/vektah/gqlparser/parser"
+	. "github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/gqlerror"
+	"github.com/dgraph-io/gqlparser/parser"
 )
 
 func LoadSchema(inputs ...*Source) (*Schema, *gqlerror.Error) {

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -179,7 +179,7 @@ func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 		if err := validateArgs(schema, field.Arguments, nil); err != nil {
 			return err
 		}
-		if err := validateDirectives(schema, field.Directives, nil); err != nil {
+		if err := validateDirectives(schema, field.Directives, LocationFieldDefinition, nil); err != nil {
 			return err
 		}
 	}
@@ -245,7 +245,7 @@ func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 		}
 	}
 
-	return validateDirectives(schema, def.Directives, nil)
+	return validateDirectives(schema, def.Directives, DirectiveLocation(def.Kind), nil)
 }
 
 func validateTypeRef(schema *Schema, typ *Type) *gqlerror.Error {
@@ -274,14 +274,14 @@ func validateArgs(schema *Schema, args ArgumentDefinitionList, currentDirective 
 				def.Kind,
 			)
 		}
-		if err := validateDirectives(schema, arg.Directives, currentDirective); err != nil {
+		if err := validateDirectives(schema, arg.Directives, LocationArgumentDefinition, currentDirective); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func validateDirectives(schema *Schema, dirs DirectiveList, currentDirective *DirectiveDefinition) *gqlerror.Error {
+func validateDirectives(schema *Schema, dirs DirectiveList, location DirectiveLocation, currentDirective *DirectiveDefinition) *gqlerror.Error {
 	for _, dir := range dirs {
 		if err := validateName(dir.Position, dir.Name); err != nil {
 			// now, GraphQL spec doesn't have reserved directive name
@@ -292,6 +292,15 @@ func validateDirectives(schema *Schema, dirs DirectiveList, currentDirective *Di
 		}
 		if schema.Directives[dir.Name] == nil {
 			return gqlerror.ErrorPosf(dir.Position, "Undefined directive %s.", dir.Name)
+		}
+		validKind := false
+		for _, dirLocation := range schema.Directives[dir.Name].Locations {
+			if dirLocation == location {
+				validKind = true
+			}
+		}
+		if !validKind {
+			return gqlerror.ErrorPosf(dir.Position, "Directive %s is not applicable on %s.", dir.Name, location)
 		}
 		dir.Definition = schema.Directives[dir.Name]
 	}

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -281,6 +281,17 @@ func validateArgs(schema *Schema, args ArgumentDefinitionList, currentDirective 
 	return nil
 }
 
+func validateDirectivesArgs(schema *Schema, dir *Directive) *gqlerror.Error {
+	dirDefinition := schema.Directives[dir.Name]
+	possibleArgsList := dirDefinition.Arguments
+	for _, arg := range dir.Arguments {
+		if possibleArgsList.ForName(arg.Name) == nil {
+			return gqlerror.ErrorPosf(arg.Position, "Invalid argument %s with Directive %s", arg.Name, dir.Name)
+		}
+	}
+	return nil
+}
+
 func validateDirectives(schema *Schema, dirs DirectiveList, location DirectiveLocation, currentDirective *DirectiveDefinition) *gqlerror.Error {
 	for _, dir := range dirs {
 		if err := validateName(dir.Position, dir.Name); err != nil {
@@ -301,6 +312,9 @@ func validateDirectives(schema *Schema, dirs DirectiveList, location DirectiveLo
 		}
 		if !validKind {
 			return gqlerror.ErrorPosf(dir.Position, "Directive %s is not applicable on %s.", dir.Name, location)
+		}
+		if err := validateDirectivesArgs(schema, dir); err != nil {
+			return err
 		}
 		dir.Definition = schema.Directives[dir.Name]
 	}

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/parser/testrunner"
+	"github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/parser/testrunner"
 )
 
 func TestLoadSchema(t *testing.T) {

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -505,6 +505,23 @@ directives:
       message: 'cannot use Interface as argument a because INTERFACE is not a valid input type'
       locations: [{line: 2, column: 14}]
 
+  - name: Invalid location usage not allowed
+    input: |
+      directive @test on FIELD_DEFINITION
+      input I1 @test { f: String }
+
+    error:
+      message: 'Directive test is not applicable on INPUT_OBJECT.'
+      locations: [{line: 2, column: 11}]
+
+  - name: Valid location usage
+    input: |
+      directive @test on FIELD_DEFINITION
+      directive @inp on INPUT_OBJECT
+      input I1 @inp { f: String }
+      type P { name: String @test }
+
+
 entry points:
   - name: multiple schema entry points
     input: |

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -520,7 +520,30 @@ directives:
       directive @inp on INPUT_OBJECT
       input I1 @inp { f: String }
       type P { name: String @test }
-
+  
+  - name: Valid directive arg inside type defn
+    input: |
+      enum DgraphIndex {
+        int
+        int64
+        float
+        bool
+        hash
+        exact
+        term
+        fulltext
+        trigram
+        regexp
+        year
+        month
+        day
+        hour
+      }
+      directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
+      type S { name: String! @search(bi: [hash]) }
+    error: 
+      message: "Invalid argument bi with Directive search"
+      locations: [{line: 18, column: 32}]
 
 entry points:
   - name: multiple schema entry points

--- a/validator/testdata/extensions.graphql
+++ b/validator/testdata/extensions.graphql
@@ -26,4 +26,4 @@ extend type Dog {
     owner: Person! @permission(permission: "admin")
 }
 
-directive @permission(permission: String!) on FIELD
+directive @permission(permission: String!) on FIELD_DEFINITION

--- a/validator/testdata/post.graphql
+++ b/validator/testdata/post.graphql
@@ -1,0 +1,39 @@
+directive @fetch(fid: String!) on OBJECT
+
+type Author @fetch(fid: "dummy") {
+  id: Int
+  firstName: String
+  lastName: String
+  posts: [Post]
+}
+
+type Post @fetch(fid: "dummy") {
+  id: Int!
+  title: String
+  text: String
+  views: Int
+}
+
+type Query {
+        getPost(id: Int!): Post
+        getAuthor(id: Int!): Author
+}
+
+input AuthorInput {
+        id: Int
+        firstName: String
+        lastName: String
+        posts: [PostInput]
+}
+
+input PostInput {
+        id: Int!
+        title: String
+        text: String
+        views: Int
+}
+
+type Mutation {
+        setAuthor(data: AuthorInput!): String
+        setPost(data: PostInput!): String
+}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	. "github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/gqlerror"
+	. "github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/gqlerror"
 )
 
 type AddErrFunc func(options ...ErrorOption)

--- a/validator/vars.go
+++ b/validator/vars.go
@@ -212,11 +212,11 @@ func (v *varValidator) getVars(typ *ast.Type, val reflect.Value) (*ast.Value, *g
 		switch typ.NamedType {
 		case "Int":
 			if kind == reflect.String {
-				_, err := strconv.ParseInt(val.String(), 10, 64)
+				res, err := strconv.ParseInt(val.String(), 10, 64)
 				if err != nil {
 					return nil, gqlerror.ErrorPathf(v.path, "Invalid %s provided : %s", kind.String(), val.String())
 				} else {
-					value.Raw = strconv.FormatInt(val.Int(), 10)
+					value.Raw = strconv.FormatInt(res, 10)
 					value.Kind = ast.IntValue
 					return value, nil
 				}
@@ -228,11 +228,11 @@ func (v *varValidator) getVars(typ *ast.Type, val reflect.Value) (*ast.Value, *g
 			}
 		case "Float":
 			if kind == reflect.String {
-				_, err := strconv.ParseFloat(val.String(), 10)
+				res, err := strconv.ParseFloat(val.String(), 10)
 				if err != nil {
 					return nil, gqlerror.ErrorPathf(v.path, "Invalid %s provided : %s", kind.String(), val.String())
 				} else {
-					value.Raw = strconv.FormatFloat(val.Float(), 'E', -1, 64)
+					value.Raw = strconv.FormatFloat(res, 'E', -1, 64)
 					value.Kind = ast.FloatValue
 					return value, nil
 				}

--- a/validator/vars.go
+++ b/validator/vars.go
@@ -211,12 +211,12 @@ func (v *varValidator) getVars(typ *ast.Type, val reflect.Value) (*ast.Value, *g
 		kind := val.Type().Kind()
 		switch typ.NamedType {
 		case "Int":
-			if kind == reflect.String || kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
+			if kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
 				value.Kind = ast.IntValue
 				return value, nil
 			}
 		case "Float":
-			if kind == reflect.String || kind == reflect.Float32 || kind == reflect.Float64 || kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
+			if kind == reflect.Float32 || kind == reflect.Float64 || kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
 				value.Kind = ast.FloatValue
 				return value, nil
 			}
@@ -233,7 +233,7 @@ func (v *varValidator) getVars(typ *ast.Type, val reflect.Value) (*ast.Value, *g
 			}
 
 		case "ID":
-			if kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 || kind == reflect.String {
+			if kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
 				value.Kind = ast.IntValue
 			}
 		default:

--- a/validator/vars.go
+++ b/validator/vars.go
@@ -6,8 +6,8 @@ import (
 
 	"fmt"
 
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/gqlerror"
+	"github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/gqlerror"
 )
 
 var UnexpectedType = fmt.Errorf("Unexpected Type")

--- a/validator/vars.go
+++ b/validator/vars.go
@@ -211,12 +211,34 @@ func (v *varValidator) getVars(typ *ast.Type, val reflect.Value) (*ast.Value, *g
 		kind := val.Type().Kind()
 		switch typ.NamedType {
 		case "Int":
+			if kind == reflect.String {
+				_, err := strconv.ParseInt(val.String(), 10, 64)
+				if err != nil {
+					return nil, gqlerror.ErrorPathf(v.path, "Invalid %s provided : %s", kind.String(), val.String())
+				} else {
+					value.Raw = strconv.FormatInt(val.Int(), 10)
+					value.Kind = ast.IntValue
+					return value, nil
+				}
+			}
 			if kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
+				value.Raw = strconv.FormatInt(val.Int(), 10)
 				value.Kind = ast.IntValue
 				return value, nil
 			}
 		case "Float":
+			if kind == reflect.String {
+				_, err := strconv.ParseFloat(val.String(), 10)
+				if err != nil {
+					return nil, gqlerror.ErrorPathf(v.path, "Invalid %s provided : %s", kind.String(), val.String())
+				} else {
+					value.Raw = strconv.FormatFloat(val.Float(), 'E', -1, 64)
+					value.Kind = ast.FloatValue
+					return value, nil
+				}
+			}
 			if kind == reflect.Float32 || kind == reflect.Float64 || kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
+				value.Raw = strconv.FormatFloat(val.Float(), 'E', -1, 64)
 				value.Kind = ast.FloatValue
 				return value, nil
 			}
@@ -229,12 +251,25 @@ func (v *varValidator) getVars(typ *ast.Type, val reflect.Value) (*ast.Value, *g
 		case "Boolean":
 			if kind == reflect.Bool {
 				value.Kind = ast.BooleanValue
+				value.Raw = strconv.FormatBool(val.Bool())
 				return value, nil
 			}
 
 		case "ID":
+			if kind == reflect.String {
+				_, err := strconv.ParseInt(val.String(), 10, 64)
+				if err != nil {
+					return nil, gqlerror.ErrorPathf(v.path, "Invalid %s provided : %s", kind.String(), val.String())
+				} else {
+					value.Raw = strconv.FormatInt(val.Int(), 10)
+					value.Kind = ast.IntValue
+					return value, nil
+				}
+			}
 			if kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
 				value.Kind = ast.IntValue
+				value.Raw = strconv.FormatInt(val.Int(), 10)
+				return value, nil
 			}
 		default:
 			// assume custom scalars are ok

--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -7,9 +7,9 @@ import (
 	"encoding/json"
 
 	"github.com/stretchr/testify/require"
-	"github.com/vektah/gqlparser"
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/validator"
+	"github.com/dgraph-io/gqlparser"
+	"github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/validator"
 )
 
 func TestValidateVars(t *testing.T) {

--- a/validator/walk.go
+++ b/validator/walk.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/vektah/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/ast"
 )
 
 type Events struct {

--- a/validator/walk_test.go
+++ b/validator/walk_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/parser"
+	"github.com/dgraph-io/gqlparser/ast"
+	"github.com/dgraph-io/gqlparser/parser"
 )
 
 func TestWalker(t *testing.T) {


### PR DESCRIPTION
Fixes GRAPHQL-671.

This PR adds argument validation in the directive validation applied to the fields inside a given type.
For example earlier 
```
type T { 
  dummyField: String! @search(xyz: [hash])
}
```
didn't return error while validation of type but now it does.