### PR TITLE
allow directives on variable definitions

### DIFF
--- a/ast/operation.go
+++ b/ast/operation.go
@@ -21,6 +21,7 @@ type VariableDefinition struct {
 	Variable     string
 	Type         *Type
 	DefaultValue *Value
+	Directives   DirectiveList
 	Position     *Position `dump:"-"`
 
 	// Requires validation

--- a/parser/query.go
+++ b/parser/query.go
@@ -101,6 +101,8 @@ func (p *parser) parseVariableDefinition() *VariableDefinition {
 		def.DefaultValue = p.parseValueLiteral(true)
 	}
 
+	def.Directives = p.parseDirectives(false)
+
 	return &def
 }
 

--- a/parser/query_test.yml
+++ b/parser/query_test.yml
@@ -41,6 +41,30 @@ variables:
       message: 'Unexpected $'
       locations: [{ line: 1, column: 37 }]
 
+  - name: can have directives
+    input: 'query ($withDirective: String @first @second, $withoutDirective: String) { f }'
+    ast: |
+      <QueryDocument>
+        Operations: [OperationDefinition]
+        - <OperationDefinition>
+            Operation: Operation("query")
+            VariableDefinitions: [VariableDefinition]
+            - <VariableDefinition>
+                Variable: "withDirective"
+                Type: String
+                Directives: [Directive]
+                - <Directive>
+                    Name: "first"
+                - <Directive>
+                    Name: "second"
+            - <VariableDefinition>
+                Variable: "withoutDirective"
+                Type: String
+            SelectionSet: [Selection]
+            - <Field>
+                Alias: "f"
+                Name: "f"
+
 fragments:
   - name: can not be named 'on'
     input: 'fragment on on on { on }'


### PR DESCRIPTION
This implements a missing part of the spec, identified by @vvakame. This seemed like an easy first contribution :) fix #102