### PR TITLE
Better handling of string lexing

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -394,6 +394,11 @@ func (s *Lexer) readString() (Token, *gqlerror.Error) {
 				case 't':
 					buf.WriteByte('\t')
 				case 'x':
+					if s.end+4 >= inputLen {
+						s.end++
+						s.endRunes++
+						break
+					}
 					// look two ahead
 					r, ok := unhex2(s.Input[s.end+2 : s.end+4])
 					if !ok {

--- a/lexer/lexer_test.yml
+++ b/lexer/lexer_test.yml
@@ -124,6 +124,15 @@ lexes strings:
         end: 15
         value: 'slashes \ /'
 
+  - name: correct hex literals
+    input: '"\xaa \xab \xac ."'
+    tokens:
+      -
+        kind: STRING
+        start: 0
+        end: 18
+        value: 'ª « ¬ .'
+
   - name: unicode
     input: '"unicode \u1234\u5678\u90AB\uCDEF"'
     tokens:
@@ -184,9 +193,12 @@ lex reports useful string errors:
 
   - name: hex escape sequence
     input: '"bad \x esc"'
-    error:
-      message: 'Invalid character escape sequence: \x.'
-      locations: [{ line: 1, column: 7 }]
+    tokens:
+      -
+        kind: STRING
+        start: 0
+        end: 12
+        value: 'bad \x esc'
 
   - name: short escape sequence
     input: '"bad \u1 esc"'
@@ -669,4 +681,3 @@ lex reports useful unknown character error:
     error:
       message: 'Cannot parse the unexpected character "â".'
       locations: [{ line: 1, column: 1 }]
-


### PR DESCRIPTION
# The Problem #
Given a schema like this:

```
type Post {
    id: ID!
    raw: String!
}
```

Here's a way to break a mutation:

```
mutation MyMutation {
  addPost(input: {raw: "\xaa Raw content"}) {
    numUids
  }
}
```
giving rise to the following error:

```
input:3: Unexpected <Invalid>
```

The issue is that `\xaa` is not parsed correctly. 

# The Solution #

The solution is quite simple: add a  case to the `readString()` method of the lexer to handle `x` as a escape character.

# Side Note: How Parsing of Strings Should Work

Please note that the handling of bad inputs for `\xHH` (where `H` is a meta-variable standing in for a hexadecimal number) is not quite the same as elsewhere in the package. I've got a good reason for this, and I am willing to make changes to the other escape sequences as well. 

With this PR, the bad inputs will lead to the literals being returned - so that `"\xZZ"` will return `"\xZZ"`, while good inputs such as `"\xaa"` will be parsed correctly, returning `"ª"`.

I believe this is more user friendly.

In the example I had listed, the scenario is one where the server is receiving a mutation. The input string, could be an end user input. And end users do often type the wrong things. 

For example, consider a dyslexic person trying to write the sentence "they will give it to me/u". Said person would often type something along the lines of "they will give it to me\u". In this case, the extra parsing for UTF-8 characters in the string will cause this input to fail. What the user meant to type, in a string representation, is `"they will give it to me\\u"`. 

An argument could be made that it is the onus of the user of this library to escape the string `"they will give it to me\u"` to `"they will give it to me\\u"`.  My counter argument is that the role of a lexer is to simply find tokens. A string token that contains the literal bytes in `"they will give it to me\u"` would qualify as a string token. That gqlparser goes above and beyond in order to parse out the UTF8 characters in the contents of a string is most commendable. 

But it should not return an error. In the example I have given so far, it would be very unfriendly to the end user, as well as the user of the library.

There can be a further argument to be made - that having the user of this library parse the string and escape any invalid sequences would be extra computation wasted. Now as a total, the program has to go through the string twice - once to escape bad sequences (done by the user of this library), and the second, to parse the correct escape sequences into UTF8 chars (done by this library). If we could save computation by doing all at once, we would make the world a much nicer place.

As I mentioned, I am willing to put the changes in for handling the rest of the bad escape sequences. I am also OK if you want to just keep returning errors for string parsing, and will modify this PR. Your call @vektah .