### PR TITLE
Fix ast.Schema inferred root types on Mutation & Subscription and `shema` definition

### DIFF
--- a/validator/schema.go
+++ b/validator/schema.go
@@ -40,8 +40,8 @@ func ValidateSchemaDocument(ast *SchemaDocument) (*Schema, *gqlerror.Error) {
 		def := schema.Types[ext.Name]
 		if def == nil {
 			schema.Types[ext.Name] = &Definition{
-				Kind:        ext.Kind,
-				Name:        ext.Name,
+				Kind:     ext.Kind,
+				Name:     ext.Name,
 				Position: ext.Position,
 			}
 			def = schema.Types[ext.Name]
@@ -134,16 +134,21 @@ func ValidateSchemaDocument(ast *SchemaDocument) (*Schema, *gqlerror.Error) {
 		}
 	}
 
-	if schema.Query == nil && schema.Types["Query"] != nil {
-		schema.Query = schema.Types["Query"]
-	}
+	// Inferred root operation type names should be performed only when a `schema` directive is
+	// **not** provided, when it is, `Mutation` and `Subscription` becomes valid types and are not
+	// assigned as a root operation on the schema.
+	if len(ast.Schema) == 0 {
+		if schema.Query == nil && schema.Types["Query"] != nil {
+			schema.Query = schema.Types["Query"]
+		}
 
-	if schema.Mutation == nil && schema.Types["Mutation"] != nil {
-		schema.Mutation = schema.Types["Mutation"]
-	}
+		if schema.Mutation == nil && schema.Types["Mutation"] != nil {
+			schema.Mutation = schema.Types["Mutation"]
+		}
 
-	if schema.Subscription == nil && schema.Types["Subscription"] != nil {
-		schema.Subscription = schema.Types["Subscription"]
+		if schema.Subscription == nil && schema.Types["Subscription"] != nil {
+			schema.Subscription = schema.Types["Subscription"]
+		}
 	}
 
 	if schema.Query != nil {

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -44,6 +44,19 @@ func TestLoadSchema(t *testing.T) {
 		require.Equal(t, "SearchResult", implements[1].Name) // union
 	})
 
+	t.Run("default root operation type names", func(t *testing.T) {
+		file, err := ioutil.ReadFile("testdata/default_root_operation_type_names.graphql")
+		require.Nil(t, err)
+		s, err := LoadSchema(Prelude, &ast.Source{Input: string(file), Name: "TestLoadSchema"})
+		require.Nil(t, err)
+
+		require.Nil(t, s.Mutation)
+		require.Nil(t, s.Subscription)
+
+		require.Equal(t, "Mutation", s.Types["Mutation"].Name)
+		require.Equal(t, "Subscription", s.Types["Subscription"].Name)
+	})
+
 	t.Run("type extensions", func(t *testing.T) {
 		file, err := ioutil.ReadFile("testdata/extensions.graphql")
 		require.Nil(t, err)

--- a/validator/testdata/default_root_operation_type_names.graphql
+++ b/validator/testdata/default_root_operation_type_names.graphql
@@ -1,0 +1,16 @@
+schema {
+    query: Query
+}
+
+type Query {
+    mutation: Mutation!
+    subscription: Subscription!
+}
+
+type Mutation {
+    name: String!
+}
+
+type Subscription {
+    name: String!
+}


### PR DESCRIPTION
The GraphQL spec defines an inference rule where a valid Schema can omit the `schema` definition and some common root type's name will be inferred as the schema's root(s).

However, when a `schema` definition is explicitly provided, it should be respected and the inference rule should not apply.

Right now, the inference is performed as soon as the `ast.Schema.<RootType>` is `nil`. This causes downstream `gqlgen` models generator to refuse to generate this type because it uses a condition `schemaType == cfg.Schema.Subscription` (https://github.com/99designs/gqlgen/blob/master/plugin/modelgen/models.go#L94) to exclude the root type from being generated which ultimately breaks the code compilation since a a type is missing.

The fix applied here is to perform the inference rule only if no `schema` definition was provided.

##### Tests

I added a test, not sure if it's at the right location for the project or not. Let me know if I should put it somewhere else.