### PR TITLE
Allow checking gqlerror.List for wrapped errors with `errors.Is` and `errors.As`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: golang:1.11
+      - image: golang:1.13
     working_directory: /gqlparser
     steps:
       - checkout

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vektah/gqlparser/v2
 
-go 1.12
+go 1.13
 
 require (
 	github.com/agnivade/levenshtein v1.0.1

--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -2,6 +2,7 @@ package gqlerror
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -78,6 +79,24 @@ func (errs List) Error() string {
 		buf.WriteByte('\n')
 	}
 	return buf.String()
+}
+
+func (errs List) Is(target error) bool {
+	for _, err := range errs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (errs List) As(target interface{}) bool {
+	for _, err := range errs {
+		if errors.As(err, target) {
+			return true
+		}
+	}
+	return false
 }
 
 func WrapPath(path ast.Path, err error) *Error {


### PR DESCRIPTION
`errors.Is` and `errors.As` will check if an error implements the interface and call the respective methods.

This allows checking if the list contains a sentinel error or getting one of a specific type. eg:

```go
// err is a gqlerrors.List{&gqlerrors.Error{Error: services.ErrInvalidSession}}
if errors.Is(err, services.ErrInvalidSession) {
	// handle sentinel error
}
```

These functions weren't added to the standard library until 1.13, so this requires that version. This could maintain older Go compatibility by copying their implementations from 1.13 if we'd like to preserve the older version support.