### PR TITLE
Stop validator mutating the provided *Schema

### DIFF
--- a/validator/rules/variables_in_allowed_position.go
+++ b/validator/rules/variables_in_allowed_position.go
@@ -12,15 +12,17 @@ func init() {
 				return
 			}
 
+			tmp := *value.ExpectedType
+
 			// todo: move me into walk
 			// If there is a default non nullable types can be null
 			if value.VariableDefinition.DefaultValue != nil && value.VariableDefinition.DefaultValue.Kind != ast.NullValue {
 				if value.ExpectedType.NonNull {
-					value.ExpectedType.NonNull = false
+					tmp.NonNull = false
 				}
 			}
 
-			if !value.VariableDefinition.Type.IsCompatible(value.ExpectedType) {
+			if !value.VariableDefinition.Type.IsCompatible(&tmp) {
 				addError(
 					Message(
 						`Variable "%s" of type "%s" used in position expecting type "%s".`,


### PR DESCRIPTION
The `VariablesInAllowedPosition` rule mutates the provided *ast.Value
which causes future validation to fails as well as altering the result
of the introspect query in gqlgen.