### PR TITLE
Fix for update by reference of default variable values

### DIFF
--- a/validator/walk.go
+++ b/validator/walk.go
@@ -193,17 +193,11 @@ func (w *Walker) walkValue(value *ast.Value) {
 
 func (w *Walker) walkArgument(argDef *ast.ArgumentDefinition, arg *ast.Argument) {
 	if argDef != nil {
-		arg.Value.ExpectedType = shallowCopy(argDef.Type)
+		arg.Value.ExpectedType = argDef.Type
 		arg.Value.Definition = w.Schema.Types[argDef.Type.Name()]
 	}
 
 	w.walkValue(arg.Value)
-}
-
-func shallowCopy(i *ast.Type) *ast.Type {
-	r := ast.Type{}
-	r = *i
-	return &r
 }
 
 func (w *Walker) walkSelectionSet(parentDef *ast.Definition, it ast.SelectionSet) {

--- a/validator/walk_test.go
+++ b/validator/walk_test.go
@@ -1,7 +1,6 @@
 package validator
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -50,25 +49,4 @@ func TestWalkInlineFragment(t *testing.T) {
 	Walk(schema, query, observers)
 
 	require.True(t, called)
-}
-
-func TestShallowCopy(t *testing.T) {
-	input := &ast.Type{
-		NamedType: "Some",
-		Elem:      nil,
-		NonNull:   false,
-		Position: &ast.Position{
-			Start:  10,
-			End:    20,
-			Line:   3,
-			Column: 4,
-			Src:    nil,
-		},
-	}
-	copied := shallowCopy(input)
-	require.Equal(t, input, copied, "have same values")
-	require.NotEqual(t, fmt.Sprintf("%p", input), fmt.Sprintf("%p", copied), "different pointers")
-	copied.NonNull = true
-	require.Equal(t, false, input.NonNull, "not change by reference")
-	require.Equal(t, true, copied.NonNull, "but changed on a copy")
 }


### PR DESCRIPTION
So `Field "..." argument "..." of type "...!" is required but not provided.` validation would always work, despite the order of the calls.

## Context of the issue 

```graphql
# Note: there is default enum value in variables
query SomeOperation ($locale: Locale! = DE) {
	myAction(myEnum: $locale) {
		id
	}
}
```
```graphql
query SomeOperation {
	# Note: Not providing mandatory parameter: (myEnum: Locale!)
	myAction {
		id
	}
}
```

* Before fix: _Missing field not caught_
* After fix: `Field "myAction" argument "myEnum" of type "Locale!" is required but not provided.`


## Cause

`VariablesInAllowedPosition` rule updates `value.ExpectedType.NonNull = false`, resulting in `ProvidedRequiredArguments` rule to have `argDef.Type.NonNull` changed on the next call.