### PR TITLE
fix issue #160: validateVarType parsing numbers

### DIFF
--- a/validator/vars.go
+++ b/validator/vars.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 
@@ -29,6 +30,7 @@ func VariableValues(schema *ast.Schema, op *ast.OperationDefinition, variables m
 		}
 
 		val, hasValue := variables[v.Variable]
+
 		if !hasValue {
 			if v.DefaultValue != nil {
 				var err error
@@ -50,6 +52,24 @@ func VariableValues(schema *ast.Schema, op *ast.OperationDefinition, variables m
 				coercedVars[v.Variable] = nil
 			} else {
 				rv := reflect.ValueOf(val)
+
+				jsonNumber, isJsonNumber := val.(json.Number)
+				if isJsonNumber {
+					if v.Type.NamedType == "Int" {
+						n, err := jsonNumber.Int64()
+						if err != nil {
+							return nil, gqlerror.ErrorPathf(validator.path, "cannot use value %s as %s", n, v.Type.NamedType)
+						}
+						rv = reflect.ValueOf(n)
+					} else if v.Type.NamedType == "Float" {
+						f, err := jsonNumber.Float64()
+						if err != nil {
+							return nil, gqlerror.ErrorPathf(validator.path, "cannot use value %f as %s", f, v.Type.NamedType)
+						}
+						rv = reflect.ValueOf(f)
+
+					}
+				}
 				if rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface {
 					rv = rv.Elem()
 				}

--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -4,8 +4,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"encoding/json"
-
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -272,10 +270,19 @@ func TestValidateVars(t *testing.T) {
 		t.Run("Json Number -> Int", func(t *testing.T) {
 			q := gqlparser.MustLoadQuery(schema, `query foo($var: Int) { optionalIntArg(i: $var) }`)
 			vars, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
-				"var": json.Number("10"),
+				"var": 10,
 			})
 			require.Nil(t, gerr)
-			require.Equal(t, json.Number("10"), vars["var"])
+			require.Equal(t, 10, vars["var"])
+		})
+
+		t.Run("Json Number -> Float", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: Float!) { floatArg(i: $var) }`)
+			vars, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": 10.2,
+			})
+			require.Nil(t, gerr)
+			require.Equal(t, 10.2, vars["var"])
 		})
 
 		t.Run("Nil -> Int", func(t *testing.T) {


### PR DESCRIPTION
This is to fix issue #160, which I run into as well.


When we find a variable which is `json.Number`, depending on the variable type request, we'll extract either the Int64 value, or the float value from the `json.Number`.

This should work well with gqlgen, which uses the json decoder `UseNumber` function to decode numbers.

https://github.com/99designs/gqlgen/blob/master/graphql/handler/transport/http_get.go#L76

Let me know if I can help make it any better, or if you have any better solution for this problem.
