### PR TITLE
Fix: argument comparison between two sets of args

### DIFF
--- a/validator/rules/overlapping_fields_can_be_merged.go
+++ b/validator/rules/overlapping_fields_can_be_merged.go
@@ -478,13 +478,15 @@ func sameArguments(args1 []*ast.Argument, args2 []*ast.Argument) bool {
 		return false
 	}
 	for _, arg1 := range args1 {
+		var matched bool
 		for _, arg2 := range args2 {
-			if arg1.Name != arg2.Name {
-				return false
+			if arg1.Name == arg2.Name && sameValue(arg1.Value, arg2.Value) {
+				matched = true
+				break
 			}
-			if !sameValue(arg1.Value, arg2.Value) {
-				return false
-			}
+		}
+		if !matched {
+			return false
 		}
 	}
 	return true

--- a/validator/rules/overlapping_fields_can_be_merged_test.go
+++ b/validator/rules/overlapping_fields_can_be_merged_test.go
@@ -98,6 +98,35 @@ func Test_sameArguments(t *testing.T) {
 			},
 			result: true,
 		},
+		"args 1 matches args 2 names and values where multiple exist in various orders": {
+			args: func() (args1 []*ast.Argument, args2 []*ast.Argument) {
+				return []*ast.Argument{
+						{
+							Name:     "thing1",
+							Value:    &ast.Value{Raw: "1 thing"},
+							Position: &ast.Position{},
+						},
+						{
+							Name:     "thing2",
+							Value:    &ast.Value{Raw: "2 thing"},
+							Position: &ast.Position{},
+						},
+					},
+					[]*ast.Argument{
+						{
+							Name:     "thing1",
+							Value:    &ast.Value{Raw: "1 thing"},
+							Position: &ast.Position{},
+						},
+						{
+							Name:     "thing2",
+							Value:    &ast.Value{Raw: "2 thing"},
+							Position: &ast.Position{},
+						},
+					}
+			},
+			result: true,
+		},
 	}
 
 	for name, tc := range tests {

--- a/validator/rules/overlapping_fields_can_be_merged_test.go
+++ b/validator/rules/overlapping_fields_can_be_merged_test.go
@@ -1,0 +1,114 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func Test_sameArguments(t *testing.T) {
+	tests := map[string]struct {
+		args   func() (args1, args2 []*ast.Argument)
+		result bool
+	}{
+		"both argument lists empty": {
+			args: func() (args1 []*ast.Argument, args2 []*ast.Argument) {
+				return nil, nil
+			},
+			result: true,
+		},
+		"args 1 empty, args 2 not": {
+			args: func() (args1 []*ast.Argument, args2 []*ast.Argument) {
+				return nil, []*ast.Argument{
+					{
+						Name:     "thing",
+						Value:    &ast.Value{Raw: "a thing"},
+						Position: &ast.Position{},
+					},
+				}
+			},
+			result: false,
+		},
+		"args 2 empty, args 1 not": {
+			args: func() (args1 []*ast.Argument, args2 []*ast.Argument) {
+				return []*ast.Argument{
+					{
+						Name:     "thing",
+						Value:    &ast.Value{Raw: "a thing"},
+						Position: &ast.Position{},
+					},
+				}, nil
+			},
+			result: false,
+		},
+		"args 1 mismatches args 2 names": {
+			args: func() (args1 []*ast.Argument, args2 []*ast.Argument) {
+				return []*ast.Argument{
+						{
+							Name:     "thing1",
+							Value:    &ast.Value{Raw: "1 thing"},
+							Position: &ast.Position{},
+						},
+					},
+					[]*ast.Argument{
+						{
+							Name:     "thing2",
+							Value:    &ast.Value{Raw: "2 thing"},
+							Position: &ast.Position{},
+						},
+					}
+			},
+			result: false,
+		},
+		"args 1 mismatches args 2 values": {
+			args: func() (args1 []*ast.Argument, args2 []*ast.Argument) {
+				return []*ast.Argument{
+						{
+							Name:     "thing1",
+							Value:    &ast.Value{Raw: "1 thing"},
+							Position: &ast.Position{},
+						},
+					},
+					[]*ast.Argument{
+						{
+							Name:     "thing1",
+							Value:    &ast.Value{Raw: "2 thing"},
+							Position: &ast.Position{},
+						},
+					}
+			},
+			result: false,
+		},
+		"args 1 matches args 2 names and values": {
+			args: func() (args1 []*ast.Argument, args2 []*ast.Argument) {
+				return []*ast.Argument{
+						{
+							Name:     "thing1",
+							Value:    &ast.Value{Raw: "1 thing"},
+							Position: &ast.Position{},
+						},
+					},
+					[]*ast.Argument{
+						{
+							Name:     "thing1",
+							Value:    &ast.Value{Raw: "1 thing"},
+							Position: &ast.Position{},
+						},
+					}
+			},
+			result: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			args1, args2 := tc.args()
+
+			resp := sameArguments(args1, args2)
+
+			if resp != tc.result {
+				t.Fatalf("Expected %t got %t", tc.result, resp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Aligns with <https://github.com/graphql/graphql-js/blob/main/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts#L626-L642>.

Added tests.

Resolves https://github.com/99designs/gqlgen/issues/1272