### PR TITLE
feat: do not mark __typename field as unknown in the schema validation

### DIFF
--- a/validator/vars.go
+++ b/validator/vars.go
@@ -1,10 +1,9 @@
 package validator
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
-
-	"fmt"
 
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -171,7 +170,10 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) (reflec
 			resetPath()
 			v.path = append(v.path, ast.PathName(name.String()))
 
-			if fieldDef == nil {
+			switch {
+			case name.String() == "__typename":
+				continue
+			case fieldDef == nil:
 				return val, gqlerror.ErrorPathf(v.path, "unknown field")
 			}
 		}

--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -1,12 +1,12 @@
 package validator_test
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"testing"
 
-	"encoding/json"
-
 	"github.com/stretchr/testify/require"
+
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/validator"
@@ -125,6 +125,19 @@ func TestValidateVars(t *testing.T) {
 				},
 			})
 			require.EqualError(t, gerr, "input: variable.var.foobard unknown field")
+		})
+
+		t.Run("unknown __typefield", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: InputType!) { structArg(i: $var) }`)
+			vars, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": map[string]interface{}{
+					"name":       "foobar",
+					"__typename": "InputType",
+				},
+			})
+			require.Nil(t, gerr)
+			require.EqualValues(t, map[string]interface{}{"__typename": "InputType", "name": "foobar"}, vars["var"])
+
 		})
 
 		t.Run("enum input object", func(t *testing.T) {


### PR DESCRIPTION
Since __typename  is commonly sent along with the mutation as since the gqlgen library allow it to be sent as well, I created this PR to avoid server errors.