### PR TITLE
fixed UniqueVariableNames validator rule to add the same error only once for #181

### DIFF
--- a/validator/rules/unique_variable_names.go
+++ b/validator/rules/unique_variable_names.go
@@ -8,15 +8,16 @@ import (
 func init() {
 	AddRule("UniqueVariableNames", func(observers *Events, addError AddErrFunc) {
 		observers.OnOperation(func(walker *Walker, operation *ast.OperationDefinition) {
-			seen := map[string]bool{}
+			seen := map[string]int{}
 			for _, def := range operation.VariableDefinitions {
-				if seen[def.Variable] {
+				// add the same error only once per a variable.
+				if seen[def.Variable] == 1 {
 					addError(
 						Message(`There can be only one variable named "$%s".`, def.Variable),
 						At(def.Position),
 					)
 				}
-				seen[def.Variable] = true
+				seen[def.Variable]++
 			}
 		})
 	})


### PR DESCRIPTION
Pass the test for #181
```
$ go test ./... -run "TestValidation/UniqueVariableNamesRule"
```