### PR TITLE
fixed UniqueArgumentNames for #181

### DIFF
--- a/validator/rules/unique_argument_names.go
+++ b/validator/rules/unique_argument_names.go
@@ -18,16 +18,16 @@ func init() {
 }
 
 func checkUniqueArgs(args ast.ArgumentList, addError AddErrFunc) {
-	knownArgNames := map[string]bool{}
+	knownArgNames := map[string]int{}
 
 	for _, arg := range args {
-		if knownArgNames[arg.Name] {
+		if knownArgNames[arg.Name] == 1 {
 			addError(
 				Message(`There can be only one argument named "%s".`, arg.Name),
 				At(arg.Position),
 			)
 		}
 
-		knownArgNames[arg.Name] = true
+		knownArgNames[arg.Name]++
 	}
 }


### PR DESCRIPTION
fixed to add the same error only once for #181

`go test ./... -run "TestValidation/UniqueArgumentNamesRule"`