### PR TITLE
added validateTypeImplementsAncestors to validate implemented types

### DIFF
--- a/validator/schema.go
+++ b/validator/schema.go
@@ -174,8 +174,8 @@ func ValidateSchemaDocument(ast *SchemaDocument) (*Schema, *gqlerror.Error) {
 
 func validateTypeDefinitions(schema *Schema) *gqlerror.Error {
 	types := make([]string, 0, len(schema.Types))
-	for _, typ := range schema.Types {
-		types = append(types, typ.Name)
+	for typ := range schema.Types {
+		types = append(types, typ)
 	}
 	sort.Strings(types)
 	for _, typ := range types {
@@ -189,8 +189,8 @@ func validateTypeDefinitions(schema *Schema) *gqlerror.Error {
 
 func validateDirectiveDefinitions(schema *Schema) *gqlerror.Error {
 	directives := make([]string, 0, len(schema.Directives))
-	for _, directive := range schema.Directives {
-		directives = append(directives, directive.Name)
+	for directive := range schema.Directives {
+		directives = append(directives, directive)
 	}
 	sort.Strings(directives)
 	for _, directive := range directives {

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -3,6 +3,7 @@
 package validator
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 
@@ -126,18 +127,12 @@ func ValidateSchemaDocument(ast *SchemaDocument) (*Schema, *gqlerror.Error) {
 		}
 	}
 
-	for _, typ := range schema.Types {
-		err := validateDefinition(&schema, typ)
-		if err != nil {
-			return nil, err
-		}
+	if err := validateTypeDefinitions(&schema); err != nil {
+		return nil, err
 	}
 
-	for _, dir := range schema.Directives {
-		err := validateDirective(&schema, dir)
-		if err != nil {
-			return nil, err
-		}
+	if err := validateDirectiveDefinitions(&schema); err != nil {
+		return nil, err
 	}
 
 	// Inferred root operation type names should be performed only when a `schema` directive is
@@ -175,6 +170,36 @@ func ValidateSchemaDocument(ast *SchemaDocument) (*Schema, *gqlerror.Error) {
 	}
 
 	return &schema, nil
+}
+
+func validateTypeDefinitions(schema *Schema) *gqlerror.Error {
+	types := make([]string, 0, len(schema.Types))
+	for _, typ := range schema.Types {
+		types = append(types, typ.Name)
+	}
+	sort.Strings(types)
+	for _, typ := range types {
+		err := validateDefinition(schema, schema.Types[typ])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateDirectiveDefinitions(schema *Schema) *gqlerror.Error {
+	directives := make([]string, 0, len(schema.Directives))
+	for _, directive := range schema.Directives {
+		directives = append(directives, directive.Name)
+	}
+	sort.Strings(directives)
+	for _, directive := range directives {
+		err := validateDirective(schema, schema.Directives[directive])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func validateDirective(schema *Schema, def *DirectiveDefinition) *gqlerror.Error {
@@ -333,7 +358,7 @@ func validateDirectives(schema *Schema, dirs DirectiveList, location DirectiveLo
 
 func validateImplements(schema *Schema, def *Definition, intfName string) *gqlerror.Error {
 	// see validation rules at the bottom of
-	// https://facebook.github.io/graphql/June2018/#sec-Objects
+	// https://facebook.github.io/graphql/October2021/#sec-Objects
 	intf := schema.Types[intfName]
 	if intf == nil {
 		return gqlerror.ErrorPosf(def.Position, "Undefined type %s.", strconv.Quote(intfName))
@@ -382,7 +407,40 @@ func validateImplements(schema *Schema, def *Definition, intfName string) *gqler
 			}
 		}
 	}
+	return validateTypeImplementsAncestors(schema, def, intfName)
+}
+
+// validateTypeImplementsAncestors
+// https://github.com/graphql/graphql-js/blob/47bd8c8897c72d3efc17ecb1599a95cee6bac5e8/src/type/validate.ts#L428
+func validateTypeImplementsAncestors(schema *Schema, def *Definition, intfName string) *gqlerror.Error {
+	intf := schema.Types[intfName]
+	if intf == nil {
+		return gqlerror.ErrorPosf(def.Position, "Undefined type %s.", strconv.Quote(intfName))
+	}
+	for _, transitive := range intf.Interfaces {
+		if !containsString(def.Interfaces, transitive) {
+			if transitive == def.Name {
+				return gqlerror.ErrorPosf(def.Position,
+					`Type %s cannot implement %s because it would create a circular reference.`,
+					def.Name, intfName,
+				)
+			}
+			return gqlerror.ErrorPosf(def.Position,
+				`Type %s must implement %s because it is implemented by %s`,
+				def.Name, transitive, intfName,
+			)
+		}
+	}
 	return nil
+}
+
+func containsString(slice []string, want string) bool {
+	for _, str := range slice {
+		if want == str {
+			return true
+		}
+	}
+	return false
 }
 
 func isCovariant(schema *Schema, required *Type, actual *Type) bool {

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -426,7 +426,7 @@ func validateTypeImplementsAncestors(schema *Schema, def *Definition, intfName s
 				)
 			}
 			return gqlerror.ErrorPosf(def.Position,
-				`Type %s must implement %s because it is implemented by %s`,
+				`Type %s must implement %s because it is implemented by %s.`,
 				def.Name, transitive, intfName,
 			)
 		}

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -286,9 +286,42 @@ interfaces:
           id: ID!
       }
 
-      type A implements IIA {
+      type A implements IIA & IA {
           id: ID!
       }
+
+  - name: Type Foo must implement Baz because it is implemented by Bar
+    input: |
+      interface Baz {
+          baz: String
+      }
+
+      interface Bar implements Baz {
+          bar: String
+          baz: String
+      }
+
+      type Foo implements Bar {
+          foo: String
+          bar: String
+          baz: String
+      }
+    error:
+      message: 'Type Foo must implement Baz because it is implemented by Bar'
+      locations: [{line: 10, column: 6}]
+
+  - name: circular reference error
+    input: |
+      interface Circular1 implements Circular2 {
+        id: ID!
+      }
+
+      interface Circular2 implements Circular1 {
+        id: ID!
+      }
+    error:
+      message: 'Type Circular1 cannot implement Circular2 because it would create a circular reference.'
+      locations: [{line: 1, column: 11}]
 
 inputs:
   - name: must define one or more input fields

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -307,7 +307,7 @@ interfaces:
           baz: String
       }
     error:
-      message: 'Type Foo must implement Baz because it is implemented by Bar'
+      message: 'Type Foo must implement Baz because it is implemented by Bar.'
       locations: [{line: 10, column: 6}]
 
   - name: circular reference error


### PR DESCRIPTION
graphql-js validated this rule for any implemented types (Object and Interface)

> Transitively implemented interfaces (interfaces implemented by the interface that is being implemented) must also be defined on an implementing type or interface. For example, `Image` cannot implement `Resource` without also implementing `Node`:

https://spec.graphql.org/October2021/#sec-Interfaces.Interfaces-Implementing-Interfaces