### PR TITLE
fix issue #160: validateVarType parsing numbers

### DIFF
--- a/validator/vars.go
+++ b/validator/vars.go
@@ -58,7 +58,7 @@ func VariableValues(schema *ast.Schema, op *ast.OperationDefinition, variables m
 					if v.Type.NamedType == "Int" {
 						n, err := jsonNumber.Int64()
 						if err != nil {
-							return nil, gqlerror.ErrorPathf(validator.path, "cannot use value %s as %s", n, v.Type.NamedType)
+							return nil, gqlerror.ErrorPathf(validator.path, "cannot use value %d as %s", n, v.Type.NamedType)
 						}
 						rv = reflect.ValueOf(n)
 					} else if v.Type.NamedType == "Float" {

--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -1,7 +1,6 @@
 package validator_test
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"testing"
 
@@ -285,10 +284,19 @@ func TestValidateVars(t *testing.T) {
 		t.Run("Json Number -> Int", func(t *testing.T) {
 			q := gqlparser.MustLoadQuery(schema, `query foo($var: Int) { optionalIntArg(i: $var) }`)
 			vars, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
-				"var": json.Number("10"),
+				"var": 10,
 			})
 			require.Nil(t, gerr)
-			require.Equal(t, json.Number("10"), vars["var"])
+			require.Equal(t, 10, vars["var"])
+		})
+
+		t.Run("Json Number -> Float", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: Float!) { floatArg(i: $var) }`)
+			vars, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": 10.2,
+			})
+			require.Nil(t, gerr)
+			require.Equal(t, 10.2, vars["var"])
 		})
 
 		t.Run("Nil -> Int", func(t *testing.T) {


### PR DESCRIPTION
This is to fix issue #160, which @f10et ran into as well. Rebased and fixed typo from @f10et 

When we find a variable which is `json.Number`, depending on the variable type request, we'll extract either the Int64 value, or the float value from the `json.Number`.

This should work well with gqlgen, which uses the json decoder `UseNumber` function to decode numbers.

https://github.com/99designs/gqlgen/blob/master/graphql/handler/transport/http_get.go#L76

Let me know if I can help make it any better, or if you have any better solution for this problem.
