### PR TITLE
formatter: skip printing insignificant commas in arguments definitions

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -299,7 +299,9 @@ func (f *formatter) FormatArgumentDefinitionList(lists ast.ArgumentDefinitionLis
 	for idx, arg := range lists {
 		f.FormatArgumentDefinition(arg)
 
-		if idx != len(lists)-1 {
+		// Skip emitting (insignificant) comma in case it is the
+		// last argument, or we printed a new line in its definition.
+		if idx != len(lists)-1 && arg.Description == "" {
 			f.NoPadding().WriteWord(",")
 		}
 	}

--- a/formatter/testdata/baseline/FormatSchema/schema.graphql
+++ b/formatter/testdata/baseline/FormatSchema/schema.graphql
@@ -33,6 +33,9 @@ type TopSubscription {
 	): Boolean
 	noop3(
 		"""noop3 foo bar"""
-		arg: String
+		arg1: String
+
+		"""noop3 foo bar"""
+		arg2: String
 	): Boolean
 }

--- a/formatter/testdata/baseline/FormatSchemaDocument/schema.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/schema.graphql
@@ -33,6 +33,9 @@ type TopSubscription {
 	): Boolean
 	noop3(
 		"""noop3 foo bar"""
-		arg: String
+		arg1: String
+
+		"""noop3 foo bar"""
+		arg2: String
 	): Boolean
 }

--- a/formatter/testdata/source/schema/schema.graphql
+++ b/formatter/testdata/source/schema/schema.graphql
@@ -41,6 +41,9 @@ type TopSubscription {
 
       noop3(
         "noop3 foo bar"
-        arg: String
+        arg1: String
+
+        "noop3 foo bar"
+        arg2: String
       ): Boolean
 }


### PR DESCRIPTION
See title. The current `formatter` prints weird output:

![image](https://user-images.githubusercontent.com/7413593/167298780-8f184bd2-3b4f-4d75-9f91-201b22a218f8.png)
