### PR TITLE
Report error about null value for any type that cannot be null, not for only built-in

### DIFF
--- a/validator/rules/values_of_correct_type.go
+++ b/validator/rules/values_of_correct_type.go
@@ -43,6 +43,8 @@ func init() {
 			}
 
 			switch value.Kind {
+			case ast.NullValue:
+				return
 			case ast.ListValue:
 				if value.ExpectedType.Elem == nil {
 					unexpectedTypeMessage(addError, value)

--- a/validator/rules/values_of_correct_type.go
+++ b/validator/rules/values_of_correct_type.go
@@ -16,6 +16,13 @@ func init() {
 				return
 			}
 
+			if value.Kind == ast.NullValue && value.ExpectedType.NonNull {
+				addError(
+					Message(`Expected value of type "%s", found %s.`, value.ExpectedType.String(), value.String()),
+					At(value.Position),
+				)
+			}
+
 			if value.Definition.Kind == ast.Scalar {
 				// Skip custom validating scalars
 				if !value.Definition.OneOf("Int", "Float", "String", "Boolean", "ID") {
@@ -36,14 +43,6 @@ func init() {
 			}
 
 			switch value.Kind {
-			case ast.NullValue:
-				if value.ExpectedType.NonNull {
-					addError(
-						Message(`Expected value of type "%s", found %s.`, value.ExpectedType.String(), value.String()),
-						At(value.Position),
-					)
-				}
-
 			case ast.ListValue:
 				if value.ExpectedType.Elem == nil {
 					unexpectedTypeMessage(addError, value)


### PR DESCRIPTION
Validator skip any checks when validating custom scalar types.
But if any type marked as not nullable ('Time!' for example) it doesn't matter what type is it custom or basic when provided 'null' value.