### PR TITLE
Allow doubly-defined builtin directives

### DIFF
--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -523,6 +523,11 @@ directives:
       message: "Cannot redeclare directive A."
       locations: [{line: 2, column: 12}]
 
+  - name: can redeclare builtin directives
+    input: |
+      directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+      directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
   - name: must be declared
     input: |
       type User {


### PR DESCRIPTION
Normally we don't want to let you define a directive twice.* But if the
directive is builtin, and one copy of it is from your schema while the
other is from the prelude, then we have to, because the spec only says
that such directives "may" be excluded from SDL. (This happens in
practice when you generate a schema from introspection, which does
define all builtins, and your generator doesn't filter them out.) So now
we allow it, only for builtin directives.

*Fun fact: technically the spec doesn't say we shouldn't. But I think
that's an error in the spec, and it's reasonable and correct to check.
In general I think the schema validation portions of the spec are
pretty incomplete :| .

Fixes #223