### PR TITLE
Replace deprecated ioutil pkg with os & io

### DIFF
--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -3,7 +3,6 @@ package formatter_test
 import (
 	"bytes"
 	"flag"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -24,10 +23,10 @@ func TestFormatter_FormatSchema(t *testing.T) {
 
 	executeGoldenTesting(t, &goldenConfig{
 		SourceDir: testSourceDir,
-		BaselineFileName: func(cfg *goldenConfig, f os.FileInfo) string {
+		BaselineFileName: func(cfg *goldenConfig, f os.DirEntry) string {
 			return path.Join(testBaselineDir, f.Name())
 		},
-		Run: func(t *testing.T, cfg *goldenConfig, f os.FileInfo) []byte {
+		Run: func(t *testing.T, cfg *goldenConfig, f os.DirEntry) []byte {
 			// load stuff
 			schema, gqlErr := gqlparser.LoadSchema(&ast.Source{
 				Name:  f.Name(),
@@ -62,10 +61,10 @@ func TestFormatter_FormatSchemaDocument(t *testing.T) {
 
 	executeGoldenTesting(t, &goldenConfig{
 		SourceDir: testSourceDir,
-		BaselineFileName: func(cfg *goldenConfig, f os.FileInfo) string {
+		BaselineFileName: func(cfg *goldenConfig, f os.DirEntry) string {
 			return path.Join(testBaselineDir, f.Name())
 		},
-		Run: func(t *testing.T, cfg *goldenConfig, f os.FileInfo) []byte {
+		Run: func(t *testing.T, cfg *goldenConfig, f os.DirEntry) []byte {
 			// load stuff
 			doc, gqlErr := parser.ParseSchema(&ast.Source{
 				Name:  f.Name(),
@@ -100,10 +99,10 @@ func TestFormatter_FormatQueryDocument(t *testing.T) {
 
 	executeGoldenTesting(t, &goldenConfig{
 		SourceDir: testSourceDir,
-		BaselineFileName: func(cfg *goldenConfig, f os.FileInfo) string {
+		BaselineFileName: func(cfg *goldenConfig, f os.DirEntry) string {
 			return path.Join(testBaselineDir, f.Name())
 		},
-		Run: func(t *testing.T, cfg *goldenConfig, f os.FileInfo) []byte {
+		Run: func(t *testing.T, cfg *goldenConfig, f os.DirEntry) []byte {
 			// load stuff
 			doc, gqlErr := parser.ParseQuery(&ast.Source{
 				Name:  f.Name(),
@@ -135,8 +134,8 @@ func TestFormatter_FormatQueryDocument(t *testing.T) {
 type goldenConfig struct {
 	SourceDir        string
 	IsTarget         func(f os.FileInfo) bool
-	BaselineFileName func(cfg *goldenConfig, f os.FileInfo) string
-	Run              func(t *testing.T, cfg *goldenConfig, f os.FileInfo) []byte
+	BaselineFileName func(cfg *goldenConfig, f os.DirEntry) string
+	Run              func(t *testing.T, cfg *goldenConfig, f os.DirEntry) []byte
 }
 
 func executeGoldenTesting(t *testing.T, cfg *goldenConfig) {
@@ -154,7 +153,7 @@ func executeGoldenTesting(t *testing.T, cfg *goldenConfig) {
 		t.Fatal("Run function is required")
 	}
 
-	fs, err := ioutil.ReadDir(cfg.SourceDir)
+	fs, err := os.ReadDir(cfg.SourceDir)
 	if err != nil {
 		t.Fatal(fs)
 	}
@@ -177,13 +176,13 @@ func executeGoldenTesting(t *testing.T, cfg *goldenConfig) {
 				}
 			}
 
-			expected, err := ioutil.ReadFile(expectedFilePath)
+			expected, err := os.ReadFile(expectedFilePath)
 			if os.IsNotExist(err) {
 				err = os.MkdirAll(path.Dir(expectedFilePath), 0755)
 				if err != nil {
 					t.Fatal(err)
 				}
-				err = ioutil.WriteFile(expectedFilePath, result, 0444)
+				err = os.WriteFile(expectedFilePath, result, 0444)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -205,7 +204,7 @@ func executeGoldenTesting(t *testing.T, cfg *goldenConfig) {
 }
 
 func mustReadFile(name string) string {
-	src, err := ioutil.ReadFile(name)
+	src, err := os.ReadFile(name)
 	if err != nil {
 		panic(err)
 	}

--- a/parser/testrunner/runner.go
+++ b/parser/testrunner/runner.go
@@ -1,7 +1,7 @@
 package testrunner
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -36,7 +36,7 @@ func (t Token) String() string {
 }
 
 func Test(t *testing.T, filename string, f func(t *testing.T, input string) Spec) {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}

--- a/validator/imported_test.go
+++ b/validator/imported_test.go
@@ -2,7 +2,6 @@ package validator_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -172,7 +171,7 @@ func compareErrors(errors gqlerror.List) func(i, j int) bool {
 }
 
 func readYaml(filename string, result interface{}) {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -1,7 +1,7 @@
 package validator
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,7 +20,7 @@ func TestLoadSchema(t *testing.T) {
 		require.Equal(t, "The `Boolean` scalar type represents `true` or `false`.", boolDef.Description)
 	})
 	t.Run("swapi", func(t *testing.T) {
-		file, err := ioutil.ReadFile("testdata/swapi.graphql")
+		file, err := os.ReadFile("testdata/swapi.graphql")
 		require.Nil(t, err)
 		s, err := LoadSchema(Prelude, &ast.Source{Input: string(file), Name: "TestLoadSchema"})
 		require.Nil(t, err)
@@ -45,7 +45,7 @@ func TestLoadSchema(t *testing.T) {
 	})
 
 	t.Run("default root operation type names", func(t *testing.T) {
-		file, err := ioutil.ReadFile("testdata/default_root_operation_type_names.graphql")
+		file, err := os.ReadFile("testdata/default_root_operation_type_names.graphql")
 		require.Nil(t, err)
 		s, err := LoadSchema(Prelude, &ast.Source{Input: string(file), Name: "TestLoadSchema"})
 		require.Nil(t, err)
@@ -58,7 +58,7 @@ func TestLoadSchema(t *testing.T) {
 	})
 
 	t.Run("type extensions", func(t *testing.T) {
-		file, err := ioutil.ReadFile("testdata/extensions.graphql")
+		file, err := os.ReadFile("testdata/extensions.graphql")
 		require.Nil(t, err)
 		s, err := LoadSchema(Prelude, &ast.Source{Input: string(file), Name: "TestLoadSchema"})
 		require.Nil(t, err)
@@ -81,7 +81,7 @@ func TestLoadSchema(t *testing.T) {
 	})
 
 	t.Run("interfaces", func(t *testing.T) {
-		file, err := ioutil.ReadFile("testdata/interfaces.graphql")
+		file, err := os.ReadFile("testdata/interfaces.graphql")
 		require.Nil(t, err)
 		s, err := LoadSchema(Prelude, &ast.Source{Input: string(file), Name: "interfaces"})
 		require.Nil(t, err)

--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -1,7 +1,7 @@
 package validator_test
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -358,7 +358,7 @@ func TestValidateVars(t *testing.T) {
 }
 
 func mustReadFile(name string) string {
-	src, err := ioutil.ReadFile(name)
+	src, err := os.ReadFile(name)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
As of Go 1.16, the same functionality is now provided by package io or
package os, and those implementations should be preferred in new code.

So replacing all usage of ioutil pkg with io & os.

Similar PR as https://github.com/99designs/gqlgen/pull/2254