### PR TITLE
Fixes #231: Parsing a field type with a bang should not increase the …

### DIFF
--- a/parser/query.go
+++ b/parser/query.go
@@ -336,7 +336,6 @@ func (p *parser) parseTypeReference() *Type {
 	}
 
 	if p.skip(lexer.Bang) {
-		typ.Position = p.peekPos()
 		typ.NonNull = true
 	}
 	return &typ

--- a/parser/schema_test.go
+++ b/parser/schema_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"github.com/stretchr/testify/assert"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"testing"
 
@@ -18,7 +19,30 @@ func TestSchemaDocument(t *testing.T) {
 			}
 		}
 		return testrunner.Spec{
-			AST:   ast.Dump(doc),
+			AST: ast.Dump(doc),
 		}
+	})
+}
+
+func TestTypePosition(t *testing.T) {
+	t.Run("type line number with no bang", func(t *testing.T) {
+		schema, parseErr := ParseSchema(&ast.Source{
+			Input: `type query {
+						me: User
+					}
+			`,
+		})
+		assert.Nil(t, parseErr)
+		assert.Equal(t, 2, schema.Definitions.ForName("query").Fields.ForName("me").Type.Position.Line)
+	})
+	t.Run("type line number with bang", func(t *testing.T) {
+		schema, parseErr := ParseSchema(&ast.Source{
+			Input: `type query {
+						me: User!
+					}
+			`,
+		})
+		assert.Nil(t, parseErr)
+		assert.Equal(t, 2, schema.Definitions.ForName("query").Fields.ForName("me").Type.Position.Line)
 	})
 }


### PR DESCRIPTION
Fix #231 

I added a new `TestTypePosition` test under `schema_test.go` because the current `TestSchemaDocument` dumps AST and ast's dumper omits `Position`. 