### PR TITLE
Prefer to wrap third party errors

### DIFF
--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -107,6 +107,13 @@ func WrapPath(path ast.Path, err error) *Error {
 	}
 }
 
+func Wrap(err error) *Error {
+	return &Error{
+		err:     err,
+		Message: err.Error(),
+	}
+}
+
 func Errorf(message string, args ...interface{}) *Error {
 	return &Error{
 		Message: fmt.Sprintf(message, args...),

--- a/gqlparser.go
+++ b/gqlparser.go
@@ -11,7 +11,15 @@ import (
 )
 
 func LoadSchema(str ...*ast.Source) (*ast.Schema, error) {
-	return validator.LoadSchema(append([]*ast.Source{validator.Prelude}, str...)...)
+	ast, err := validator.LoadSchema(append([]*ast.Source{validator.Prelude}, str...)...)
+	gqlErr, ok := err.(*gqlerror.Error)
+	if ok {
+		return ast, gqlErr
+	}
+	if err != nil {
+		return ast, gqlerror.Wrap(err)
+	}
+	return ast, nil
 }
 
 func MustLoadSchema(str ...*ast.Source) *ast.Schema {
@@ -25,11 +33,14 @@ func MustLoadSchema(str ...*ast.Source) *ast.Schema {
 func LoadQuery(schema *ast.Schema, str string) (*ast.QueryDocument, gqlerror.List) {
 	query, err := parser.ParseQuery(&ast.Source{Input: str})
 	if err != nil {
-		gqlErr := err.(*gqlerror.Error)
-		return nil, gqlerror.List{gqlErr}
+		gqlErr, ok := err.(*gqlerror.Error)
+		if ok {
+			return nil, gqlerror.List{gqlErr}
+		}
+		return nil, gqlerror.List{gqlerror.Wrap(err)}
 	}
 	errs := validator.Validate(schema, query)
-	if errs != nil {
+	if len(errs) > 0 {
 		return nil, errs
 	}
 

--- a/parser/testrunner/runner.go
+++ b/parser/testrunner/runner.go
@@ -55,8 +55,12 @@ func Test(t *testing.T, filename string, f func(t *testing.T, input string) Spec
 
 					if spec.Error == nil {
 						if result.Error != nil {
-							gqlErr := err.(*gqlerror.Error)
-							t.Errorf("unexpected error %s", gqlErr.Message)
+							gqlErr, ok := err.(*gqlerror.Error)
+							if ok {
+								t.Errorf("unexpected error %s", gqlErr.Message)
+							} else {
+								t.Errorf("unexpected error %+v", gqlerror.Wrap(err))
+							}
 						}
 					} else if result.Error == nil {
 						t.Errorf("expected error but got none")

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -25,7 +25,15 @@ func AddRule(name string, f ruleFunc) {
 
 func Validate(schema *Schema, doc *QueryDocument) gqlerror.List {
 	var errs gqlerror.List
-
+	if schema == nil {
+		errs = append(errs, gqlerror.Errorf("cannot validate as Schema is nil"))
+	}
+	if doc == nil {
+		errs = append(errs, gqlerror.Errorf("cannot validate as QueryDocument is nil"))
+	}
+	if len(errs) > 0 {
+		return errs
+	}
 	observers := &Events{}
 	for i := range rules {
 		rule := rules[i]


### PR DESCRIPTION
Prior to #234 the method signature returned `*gqlerror.Error` which would return a typed nil, so that:
```
if err != nil {
```
would fail to detect errors.

Consumers of this library when the method signature returned `*gqlerror.Error` would frequently do this:
```
if gqlError != (*gqlerror.Error)(nil) {
```

Now that the method signature is to return the `error` interface the first one worked, and the second one no longer does  (as it is now always untyped nil). 😞 

Similarly, others consumers assume the `error` interface we return can *always* be asserted as `(*gqlerror.Error)` which is not entirely true, as we have some third-party errors which we return without wrapping.

This wraps a few of the most common calls to be able to be asserted as `*gqlerror.Error` without changing the return signature. However, there are a number of third-party errors we cannot easily wrap at the point of origination because it would cause cyclical dependencies. 


I ran [wrapcheck](https://github.com/tomarrell/wrapcheck) configured to ignore this package and found:
```
gqlparser/ast/decode.go:56:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:61:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:72:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:77:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:87:10: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:94:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:99:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:110:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:115:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:125:10: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:132:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:137:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:142:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:147:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:158:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:168:10: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:175:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:180:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:185:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:190:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:201:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:206:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/decode.go:211:12: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/path.go:42:10: error returned from external package is unwrapped: sig: func encoding/json.Unmarshal(data []byte, v any) error
gqlparser/ast/value.go:56:10: error returned from external package is unwrapped: sig: func strconv.ParseInt(s string, base int, bitSize int) (i int64, err error)
gqlparser/ast/value.go:58:10: error returned from external package is unwrapped: sig: func strconv.ParseFloat(s string, bitSize int) (float64, error)
gqlparser/ast/value.go:62:10: error returned from external package is unwrapped: sig: func strconv.ParseBool(str string) (bool, error)
gqlparser/validator/schema.go:17:15: error returned from external package is unwrapped: sig: func github.com/vektah/gqlparser/v2/parser.ParseSchemas(inputs ...*github.com/vektah/gqlparser/v2/ast.Source) (*github.com/vektah/gqlparser/v2/ast.SchemaDocument, error)
```
Signed-off-by: Steve Coffman <steve@khanacademy.org>

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature 
 - [ ] Updated any relevant documentation
