### PR TITLE
Add benchmarks and workflows using benchstat

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -54,3 +54,63 @@ jobs:
       - name: Unit Test Golang
         run: go test ./...
         timeout-minutes: 30
+
+  benchstat:
+    name: Report benchmark stat
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.16.x
+
+      - name: Setup Golang caches
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golang-
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      - name: Checkout (master branch)
+        uses: actions/checkout@v3
+        with:
+          ref: master
+      - name: Run benchmark (master branch)
+        run: go test -bench . | tee /tmp/old.txt
+
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run benchmark
+        run: go test -bench . | tee /tmp/new.txt
+
+      - id: benchstat
+        name: Run benchstat
+        run: |
+          benchstat /tmp/old.txt /tmp/new.txt | tee bench_result.txt
+          body="$(cat bench_result.txt)"
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo "::set-output name=body::$body"
+
+      - name: Add comment
+        # From the official documentation.
+        # https://docs.github.com/en/actions/managing-issues-and-pull-requests/commenting-on-an-issue-when-a-label-is-added#creating-the-workflow
+        uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          token: ${{ secrets.PAT }}
+          body: |
+            Benchmark results:
+            ```
+            ${{ steps.benchstat.outputs.body }}
+            ```

--- a/gqlparser_bench_test.go
+++ b/gqlparser_bench_test.go
@@ -1,0 +1,57 @@
+package gqlparser_test
+
+import (
+	"testing"
+
+	"github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+const (
+	testSchema1 = `
+type Color {
+  hex: String!
+  r: Int!
+  g: Int!
+  b: Int!
+}
+
+type Query {
+  colors: [Color]
+}`
+
+	testQuery1 = `
+query {
+  colors {
+    hex
+    r
+    g
+    b
+  }
+}`
+)
+
+func BenchmarkLoadSchema(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := gqlparser.LoadSchema(&ast.Source{Input: testSchema1})
+		if err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+func BenchmarkLoadQuery(b *testing.B) {
+	schema, err := gqlparser.LoadSchema(&ast.Source{Input: testSchema1})
+	if err != nil {
+		b.Fatalf("unexpected error: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, errs := gqlparser.LoadQuery(schema, testQuery1)
+		if errs != nil {
+			b.Fatalf("unexpected errors: %v", errs)
+		}
+	}
+}


### PR DESCRIPTION
This is a draft of issue https://github.com/vektah/gqlparser/issues/246.

PR includes:

* Benchmarks of `LoadSchema` and `LoadQuery` in [gqlparser_bench_test.go](https://github.com/vektah/gqlparser/blob/4a7076be7757e8b4853c0f46c688b24d57e683b1/gqlparser_bench_test.go#L34).
* GHA workflow to report benchmark comparisons with master branch to PR

The reporting is displayed like this.
<img width="921" alt="Screen Shot 2022-09-25 at 14 27 12" src="https://user-images.githubusercontent.com/37844673/192129698-77390a36-5556-4d30-877c-34efddef1a82.png">

https://github.com/ryicoh/gqlparser/pull/3#issuecomment-1257117351

There are a lot of things to discuss.
* Is benchmarking really necessary?
* How about schemas and queries for benchmarks. Test data already exists here.  [validator/testdata](https://github.com/vektah/gqlparser/tree/master/validator/testdata) 
* Use [golang.org/x/perf/cmd/benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) ?
* Made PAT(Personal Access Token) for a reporting, but how do we manage the Secret?
https://github.com/vektah/gqlparser/blob/4a7076be7757e8b4853c0f46c688b24d57e683b1/.github/workflows/pull-request.yml#L111