### PR TITLE
Point to the right GraphQL spec

### DIFF
--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -9,7 +9,7 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
-// Error is the standard graphql error type described in https://facebook.github.io/graphql/draft/#sec-Errors
+// Error is the standard graphql error type described in https://spec.graphql.org/draft/#sec-Errors
 type Error struct {
 	err        error                  `json:"-"`
 	Message    string                 `json:"message"`

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -379,7 +379,7 @@ func validateDirectives(schema *Schema, dirs DirectiveList, location DirectiveLo
 
 func validateImplements(schema *Schema, def *Definition, intfName string) *gqlerror.Error {
 	// see validation rules at the bottom of
-	// https://facebook.github.io/graphql/October2021/#sec-Objects
+	// https://spec.graphql.org/October2021/#sec-Objects
 	intf := schema.Types[intfName]
 	if intf == nil {
 		return gqlerror.ErrorPosf(def.Position, "Undefined type %s.", strconv.Quote(intfName))


### PR DESCRIPTION
https://facebook.github.io/graphql is a broken link. Now the GraphQL spec is hosted at https://spec.graphql.org

