### PR TITLE
Validate enum values directive are legit

### DIFF
--- a/validator/schema.go
+++ b/validator/schema.go
@@ -284,6 +284,9 @@ func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 					return gqlerror.ErrorPosf(def.Position, "%s %s: non-enum value %s.", def.Kind, def.Name, value.Name)
 				}
 			}
+			if err := validateDirectives(schema, value.Directives, LocationEnumValue, nil); err != nil {
+				return err
+			}
 		}
 	case InputObject:
 		if len(def.Fields) == 0 {

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -528,7 +528,16 @@ directives:
       directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
       directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-  - name: must be declared
+  - name: must be declared (type)
+    input: |
+      type User @foo {
+        name: String
+      }
+    error:
+      message: "Undefined directive foo."
+      locations: [{line: 1, column: 12}]
+
+  - name: must be declared (field)
     input: |
       type User {
         name: String @foo
@@ -536,6 +545,15 @@ directives:
     error:
       message: "Undefined directive foo."
       locations: [{line: 2, column: 17}]
+
+  - name: must be declared (enum)
+    input: |
+      enum Unit {
+        METER @foo
+      }
+    error:
+      message: "Undefined directive foo."
+      locations: [{line: 2, column: 10}]
 
   - name: cannot be self-referential
     input: |


### PR DESCRIPTION
Directives on enum values aren't validated during parsing.

`must be declared (enum)` is the new test that was failing before.

I have:
 - [x] Added tests covering the bug / feature 
 - [x] Updated any relevant documentation
