### PR TITLE
Validate directive arguments during schema parsing

### DIFF
--- a/validator/schema.go
+++ b/validator/schema.go
@@ -359,11 +359,12 @@ func validateDirectives(schema *Schema, dirs DirectiveList, location DirectiveLo
 		if currentDirective != nil && dir.Name == currentDirective.Name {
 			return gqlerror.ErrorPosf(dir.Position, "Directive %s cannot refer to itself.", currentDirective.Name)
 		}
-		if schema.Directives[dir.Name] == nil {
+		dirDefinition := schema.Directives[dir.Name]
+		if dirDefinition == nil {
 			return gqlerror.ErrorPosf(dir.Position, "Undefined directive %s.", dir.Name)
 		}
 		validKind := false
-		for _, dirLocation := range schema.Directives[dir.Name].Locations {
+		for _, dirLocation := range dirDefinition.Locations {
 			if dirLocation == location {
 				validKind = true
 				break
@@ -371,6 +372,17 @@ func validateDirectives(schema *Schema, dirs DirectiveList, location DirectiveLo
 		}
 		if !validKind {
 			return gqlerror.ErrorPosf(dir.Position, "Directive %s is not applicable on %s.", dir.Name, location)
+		}
+		possibleArgsList := dirDefinition.Arguments
+		for _, arg := range dir.Arguments {
+			if possibleArgsList.ForName(arg.Name) == nil {
+				return gqlerror.ErrorPosf(arg.Position, "Undefined argument %s for directive %s.", arg.Name, dir.Name)
+			}
+		}
+		for _, schemaArg := range possibleArgsList {
+			if schemaArg.Type.NonNull && dir.Arguments.ForName(schemaArg.Name) == nil {
+				return gqlerror.ErrorPosf(dir.Position, "Argument %s for directive %s cannot be null.", schemaArg.Name, dir.Name)
+			}
 		}
 		dir.Definition = schema.Directives[dir.Name]
 	}

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -373,13 +373,12 @@ func validateDirectives(schema *Schema, dirs DirectiveList, location DirectiveLo
 		if !validKind {
 			return gqlerror.ErrorPosf(dir.Position, "Directive %s is not applicable on %s.", dir.Name, location)
 		}
-		possibleArgsList := dirDefinition.Arguments
 		for _, arg := range dir.Arguments {
-			if possibleArgsList.ForName(arg.Name) == nil {
+			if dirDefinition.Arguments.ForName(arg.Name) == nil {
 				return gqlerror.ErrorPosf(arg.Position, "Undefined argument %s for directive %s.", arg.Name, dir.Name)
 			}
 		}
-		for _, schemaArg := range possibleArgsList {
+		for _, schemaArg := range dirDefinition.Arguments {
 			if schemaArg.Type.NonNull && dir.Arguments.ForName(schemaArg.Name) == nil {
 				return gqlerror.ErrorPosf(dir.Position, "Argument %s for directive %s cannot be null.", schemaArg.Name, dir.Name)
 			}

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -379,8 +379,10 @@ func validateDirectives(schema *Schema, dirs DirectiveList, location DirectiveLo
 			}
 		}
 		for _, schemaArg := range dirDefinition.Arguments {
-			if schemaArg.Type.NonNull && dir.Arguments.ForName(schemaArg.Name) == nil {
-				return gqlerror.ErrorPosf(dir.Position, "Argument %s for directive %s cannot be null.", schemaArg.Name, dir.Name)
+			if schemaArg.Type.NonNull {
+				if arg := dir.Arguments.ForName(schemaArg.Name); arg == nil || arg.Value.Kind == NullValue {
+					return gqlerror.ErrorPosf(dir.Position, "Argument %s for directive %s cannot be null.", schemaArg.Name, dir.Name)
+				}
 			}
 		}
 		dir.Definition = schema.Directives[dir.Name]

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -613,10 +613,19 @@ directives:
       message: 'Undefined argument foobla for directive foo.'
       locations: [{line: 2, column: 21}]
 
-  - name: Nil value not allowed for non-null types
+  - name: non-null argument must be provided
     input: |
       directive @foo(bla: Int!) on FIELD_DEFINITION
       type P {f: Int @foo }
+    
+    error:
+      message: 'Argument bla for directive foo cannot be null.'
+      locations: [{line: 2, column: 17}]
+
+  - name: non-null argument must not be null
+    input: |
+      directive @foo(bla: Int!) on FIELD_DEFINITION
+      type P {f: Int @foo(bla: null) }
     
     error:
       message: 'Argument bla for directive foo cannot be null.'

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -604,6 +604,23 @@ directives:
       type P { name: String @testField }
       interface I { id: ID @testField }
 
+  - name: Invalid directive argument not allowed
+    input: |
+      directive @foo(bla: Int!) on FIELD_DEFINITION
+      type P {f: Int @foo(foobla: 11)}
+    
+    error:
+      message: 'Undefined argument foobla for directive foo.'
+      locations: [{line: 2, column: 21}]
+
+  - name: Nil value not allowed for non-null types
+    input: |
+      directive @foo(bla: Int!) on FIELD_DEFINITION
+      type P {f: Int @foo }
+    
+    error:
+      message: 'Argument bla for directive foo cannot be null.'
+      locations: [{line: 2, column: 17}]
 
 entry points:
   - name: multiple schema entry points


### PR DESCRIPTION
FIx https://github.com/vektah/gqlparser/issues/107

Directives should validate argument names and non-null fields.

Try to get a similar change as https://github.com/dgraph-io/gqlparser/pull/2 in.

I have:
 - [x] Added tests covering the bug / feature 
 - [x] Updated any relevant documentation
