### PR TITLE
feat: support end of definition comment and end of file comment

### DIFF
--- a/ast/definition.go
+++ b/ast/definition.go
@@ -34,6 +34,7 @@ type Definition struct {
 
 	BeforeDescriptionComment *CommentGroup
 	AfterDescriptionComment  *CommentGroup
+	EndOfDefinitionComment   *CommentGroup
 }
 
 func (d *Definition) IsLeafType() bool {

--- a/ast/document.go
+++ b/ast/document.go
@@ -77,6 +77,7 @@ type SchemaDefinition struct {
 
 	BeforeDescriptionComment *CommentGroup
 	AfterDescriptionComment  *CommentGroup
+	EndOfDefinitionComment   *CommentGroup
 }
 
 type OperationTypeDefinition struct {

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -225,6 +225,26 @@ func (f *formatter) FormatSchemaDefinitionList(lists ast.SchemaDefinitionList, e
 		return
 	}
 
+	var (
+		beforeDescComment = new(ast.CommentGroup)
+		afterDescComment  = new(ast.CommentGroup)
+		description       string
+	)
+
+	for _, def := range lists {
+		if def.BeforeDescriptionComment != nil {
+			beforeDescComment.List = append(beforeDescComment.List, def.BeforeDescriptionComment.List...)
+		}
+		if def.AfterDescriptionComment != nil {
+			afterDescComment.List = append(afterDescComment.List, def.AfterDescriptionComment.List...)
+		}
+		description += def.Description
+	}
+
+	f.FormatCommentGroup(beforeDescComment)
+	f.WriteDescription(description)
+	f.FormatCommentGroup(afterDescComment)
+
 	if extension {
 		f.WriteWord("extend")
 	}
@@ -240,12 +260,6 @@ func (f *formatter) FormatSchemaDefinitionList(lists ast.SchemaDefinitionList, e
 }
 
 func (f *formatter) FormatSchemaDefinition(def *ast.SchemaDefinition) {
-	f.FormatCommentGroup(def.BeforeDescriptionComment)
-
-	f.WriteDescription(def.Description)
-
-	f.FormatCommentGroup(def.AfterDescriptionComment)
-
 	f.FormatDirectiveList(def.Directives)
 
 	f.FormatOperationTypeDefinitionList(def.OperationTypes)

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -264,7 +264,7 @@ func (f *formatter) FormatOperationTypeDefinition(def *ast.OperationTypeDefiniti
 	f.WriteNewline()
 }
 
-func (f *formatter) FormatFieldList(fieldList ast.FieldList) {
+func (f *formatter) FormatFieldList(fieldList ast.FieldList, endOfDefComment *ast.CommentGroup) {
 	if len(fieldList) == 0 {
 		return
 	}
@@ -275,6 +275,8 @@ func (f *formatter) FormatFieldList(fieldList ast.FieldList) {
 	for _, field := range fieldList {
 		f.FormatFieldDefinition(field)
 	}
+
+	f.FormatCommentGroup(endOfDefComment)
 
 	f.DecrementIndent()
 	f.WriteString("}")
@@ -458,14 +460,14 @@ func (f *formatter) FormatDefinition(def *ast.Definition, extend bool) {
 		f.WriteWord("=").WriteWord(strings.Join(def.Types, " | "))
 	}
 
-	f.FormatFieldList(def.Fields)
+	f.FormatFieldList(def.Fields, def.EndOfDefinitionComment)
 
-	f.FormatEnumValueList(def.EnumValues)
+	f.FormatEnumValueList(def.EnumValues, def.EndOfDefinitionComment)
 
 	f.WriteNewline()
 }
 
-func (f *formatter) FormatEnumValueList(lists ast.EnumValueList) {
+func (f *formatter) FormatEnumValueList(lists ast.EnumValueList, endOfDefComment *ast.CommentGroup) {
 	if len(lists) == 0 {
 		return
 	}
@@ -476,6 +478,8 @@ func (f *formatter) FormatEnumValueList(lists ast.EnumValueList) {
 	for _, v := range lists {
 		f.FormatEnumValueDefinition(v)
 	}
+
+	f.FormatCommentGroup(endOfDefComment)
 
 	f.DecrementIndent()
 	f.WriteString("}")

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -196,8 +196,6 @@ func (f *formatter) FormatSchemaDocument(doc *ast.SchemaDocument) {
 		return
 	}
 
-	f.FormatCommentGroup(doc.Comment)
-
 	f.FormatSchemaDefinitionList(doc.Schema, false)
 	f.FormatSchemaDefinitionList(doc.SchemaExtension, true)
 
@@ -205,6 +203,9 @@ func (f *formatter) FormatSchemaDocument(doc *ast.SchemaDocument) {
 
 	f.FormatDefinitionList(doc.Definitions, false)
 	f.FormatDefinitionList(doc.Extensions, true)
+
+	// doc.Comment is end of file comment, so emit last
+	f.FormatCommentGroup(doc.Comment)
 }
 
 func (f *formatter) FormatQueryDocument(doc *ast.QueryDocument) {
@@ -226,9 +227,10 @@ func (f *formatter) FormatSchemaDefinitionList(lists ast.SchemaDefinitionList, e
 	}
 
 	var (
-		beforeDescComment = new(ast.CommentGroup)
-		afterDescComment  = new(ast.CommentGroup)
-		description       string
+		beforeDescComment      = new(ast.CommentGroup)
+		afterDescComment       = new(ast.CommentGroup)
+		endOfDefinitionComment = new(ast.CommentGroup)
+		description            string
 	)
 
 	for _, def := range lists {
@@ -237,6 +239,9 @@ func (f *formatter) FormatSchemaDefinitionList(lists ast.SchemaDefinitionList, e
 		}
 		if def.AfterDescriptionComment != nil {
 			afterDescComment.List = append(afterDescComment.List, def.AfterDescriptionComment.List...)
+		}
+		if def.EndOfDefinitionComment != nil {
+			endOfDefinitionComment.List = append(endOfDefinitionComment.List, def.EndOfDefinitionComment.List...)
 		}
 		description += def.Description
 	}
@@ -254,6 +259,8 @@ func (f *formatter) FormatSchemaDefinitionList(lists ast.SchemaDefinitionList, e
 	for _, def := range lists {
 		f.FormatSchemaDefinition(def)
 	}
+
+	f.FormatCommentGroup(endOfDefinitionComment)
 
 	f.DecrementIndent()
 	f.WriteString("}").WriteNewline()

--- a/formatter/testdata/baseline/FormatSchema/definition.graphql
+++ b/formatter/testdata/baseline/FormatSchema/definition.graphql
@@ -6,11 +6,13 @@ scalar Cat0
 type Cat1 {
 	# Cat1 name comment
 	name: String
+	# end of Cat1 comment
 }
 # Cat2 comment
 interface Cat2 {
 	# Cat2 name comment
 	name: String
+	# end of Cat2 comment
 }
 # Cat3 comment
 union Cat3 = Cat3_0 | Cat3_1 | Cat3_2
@@ -35,9 +37,11 @@ enum Cat4 {
 	NFC
 	# Cat4 MAINECOON comment
 	MAINECOON
+	# end of Cat4 comment
 }
 # Cat5 comment
 input Cat5 {
 	# Cat5 name comment
 	name: String
+	# end of Cat5 comment
 }

--- a/formatter/testdata/baseline/FormatSchema/extensions.graphql
+++ b/formatter/testdata/baseline/FormatSchema/extensions.graphql
@@ -10,19 +10,23 @@ type Dog {
 	name: String!
 	# Dog owner comment
 	owner: Person! @permission(permission: "admin")
+	# end of type comment
 }
 # Person comment
 type Person @key(fields: "name") {
 	# Person name comment
 	name: String!
+	# end of type comment
 }
 # query extends comment
 type Query @extends {
 	# dogs comment
 	dogs: [Dog!]!
+	# end of type comment
 }
 # subscription comment
 type Subscription {
 	# dogEvents comment
 	dogEvents: [Dog!]!
+	# end of type comment
 }

--- a/formatter/testdata/baseline/FormatSchemaDocument/definition.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/definition.graphql
@@ -6,11 +6,13 @@ scalar Cat0
 type Cat1 {
 	# Cat1 name comment
 	name: String
+	# end of Cat1 comment
 }
 # Cat2 comment
 interface Cat2 {
 	# Cat2 name comment
 	name: String
+	# end of Cat2 comment
 }
 # Cat3_0 comment
 type Cat3_0 {
@@ -35,9 +37,11 @@ enum Cat4 {
 	NFC
 	# Cat4 MAINECOON comment
 	MAINECOON
+	# end of Cat4 comment
 }
 # Cat5 comment
 input Cat5 {
 	# Cat5 name comment
 	name: String
+	# end of Cat5 comment
 }

--- a/formatter/testdata/baseline/FormatSchemaDocument/definition.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/definition.graphql
@@ -45,3 +45,5 @@ input Cat5 {
 	name: String
 	# end of Cat5 comment
 }
+# end of file comment
+# end of file comment 2

--- a/formatter/testdata/baseline/FormatSchemaDocument/description.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/description.graphql
@@ -10,3 +10,5 @@ type Cat {
 	# field comment
 	name: String
 }
+# end of file comment
+# end of file comment 2

--- a/formatter/testdata/baseline/FormatSchemaDocument/directive.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/directive.graphql
@@ -1,2 +1,4 @@
 directive @foo on FIELD | OBJECT
 directive @bar repeatable on FIELD | OBJECT
+# end of file comment
+# end of file comment 2

--- a/formatter/testdata/baseline/FormatSchemaDocument/directive_locations.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/directive_locations.graphql
@@ -11,3 +11,5 @@ enum ConnectionStatus @foo {
 	ERROR
 }
 union PersonUnion @foo = Person
+# end of file comment
+# end of file comment 2

--- a/formatter/testdata/baseline/FormatSchemaDocument/extensions.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/extensions.graphql
@@ -42,3 +42,5 @@ extend type Dog {
 	owner: Person! @permission(permission: "admin")
 	# end of type comment
 }
+# end of file comment
+# end of file comment 2

--- a/formatter/testdata/baseline/FormatSchemaDocument/extensions.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/extensions.graphql
@@ -16,24 +16,29 @@ directive @key(fields: String!) on OBJECT | INTERFACE
 type Query @extends {
 	# dogs comment
 	dogs: [Dog!]!
+	# end of type comment
 }
 # subscription comment
 type Subscription {
 	# dogEvents comment
 	dogEvents: [Dog!]!
+	# end of type comment
 }
 # Dog comment
 type Dog {
 	# Dog name comment
 	name: String!
+	# end of type comment
 }
 # Person comment
 type Person @key(fields: "name") {
 	# Person name comment
 	name: String!
+	# end of type comment
 }
 # extend type Dog comment
 extend type Dog {
 	# Dog owner comment
 	owner: Person! @permission(permission: "admin")
+	# end of type comment
 }

--- a/formatter/testdata/baseline/FormatSchemaDocument/field_definition.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/field_definition.graphql
@@ -1,3 +1,5 @@
 input CatInput {
 	food: String = "fish & meat"
 }
+# end of file comment
+# end of file comment 2

--- a/formatter/testdata/baseline/FormatSchemaDocument/schema.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/schema.graphql
@@ -1,7 +1,14 @@
+# before schema description comment
+"""schema description"""
+# after schema description comment
 schema {
+	# before query comment
 	query: TopQuery
+	# before mutation comment
 	mutation: TopMutation
+	# before subscription comment
 	subscription: TopSubscription
+	# end of schema comment
 }
 type TopMutation {
 	noop: Boolean

--- a/formatter/testdata/baseline/FormatSchemaDocument/schema.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/schema.graphql
@@ -46,3 +46,5 @@ type TopSubscription {
 		arg2: String
 	): Boolean
 }
+# end of file comment
+# end of file comment 2

--- a/formatter/testdata/source/schema/definition.graphql
+++ b/formatter/testdata/source/schema/definition.graphql
@@ -45,4 +45,5 @@ input Cat5 {
     name: String
     # end of Cat5 comment
 }
-
+# end of file comment
+# end of file comment 2

--- a/formatter/testdata/source/schema/definition.graphql
+++ b/formatter/testdata/source/schema/definition.graphql
@@ -6,11 +6,13 @@ scalar Cat0
 type Cat1 {
     # Cat1 name comment
     name: String
+    # end of Cat1 comment
 }
 # Cat2 comment
 interface Cat2 {
     # Cat2 name comment
     name: String
+    # end of Cat2 comment
 }
 # Cat3_0 comment
 type Cat3_0 {
@@ -35,10 +37,12 @@ enum Cat4 {
     NFC
     # Cat4 MAINECOON comment
     MAINECOON
+    # end of Cat4 comment
 }
 # Cat5 comment
 input Cat5 {
     # Cat5 name comment
     name: String
+    # end of Cat5 comment
 }
 

--- a/formatter/testdata/source/schema/description.graphql
+++ b/formatter/testdata/source/schema/description.graphql
@@ -10,3 +10,5 @@ type Cat {
     # field comment
     name: String
 }
+# end of file comment
+# end of file comment 2

--- a/formatter/testdata/source/schema/directive.graphql
+++ b/formatter/testdata/source/schema/directive.graphql
@@ -1,2 +1,4 @@
 directive @foo on FIELD|OBJECT
 directive @bar repeatable on FIELD|OBJECT
+# end of file comment
+# end of file comment 2

--- a/formatter/testdata/source/schema/directive_locations.graphql
+++ b/formatter/testdata/source/schema/directive_locations.graphql
@@ -11,3 +11,5 @@ enum ConnectionStatus @foo {
 	ERROR
 }
 union PersonUnion @foo = Person
+# end of file comment
+# end of file comment 2

--- a/formatter/testdata/source/schema/extensions.graphql
+++ b/formatter/testdata/source/schema/extensions.graphql
@@ -49,3 +49,5 @@ directive @permission(permission: String!) on FIELD_DEFINITION
 directive @extends on OBJECT
 # directive @key comment
 directive @key(fields: String!) on OBJECT | INTERFACE
+# end of file comment
+# end of file comment 2

--- a/formatter/testdata/source/schema/extensions.graphql
+++ b/formatter/testdata/source/schema/extensions.graphql
@@ -12,30 +12,35 @@ extend schema {
 type Query @extends {
     # dogs comment
     dogs: [Dog!]!
+    # end of type comment
 }
 
 # subscription comment
 type Subscription {
     # dogEvents comment
     dogEvents: [Dog!]!
+    # end of type comment
 }
 
 # Dog comment
 type Dog {
     # Dog name comment
     name: String!
+    # end of type comment
 }
 
 # Person comment
 type Person @key(fields: "name") {
     # Person name comment
     name: String!
+    # end of type comment
 }
 
 # extend type Dog comment
 extend type Dog {
     # Dog owner comment
     owner: Person! @permission(permission: "admin")
+    # end of type comment
 }
 
 # directive @persmission comment

--- a/formatter/testdata/source/schema/field_definition.graphql
+++ b/formatter/testdata/source/schema/field_definition.graphql
@@ -1,3 +1,5 @@
 input CatInput {
     food: String = "fish & meat"
 }
+# end of file comment
+# end of file comment 2

--- a/formatter/testdata/source/schema/schema.graphql
+++ b/formatter/testdata/source/schema/schema.graphql
@@ -1,7 +1,14 @@
+# before schema description comment
+"schema description"
+# after schema description comment
 schema {
+  # before query comment
 	query: TopQuery
+  # before mutation comment
 	mutation: TopMutation
+  # before subscription comment
 	subscription: TopSubscription
+  # end of schema comment
 }
 
 type TopMutation {

--- a/formatter/testdata/source/schema/schema.graphql
+++ b/formatter/testdata/source/schema/schema.graphql
@@ -54,3 +54,5 @@ type TopSubscription {
         arg2: String
       ): Boolean
 }
+# end of file comment
+# end of file comment 2

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -164,10 +164,10 @@ func (p *parser) many(start lexer.Type, end lexer.Type, cb func()) {
 	p.next()
 }
 
-func (p *parser) some(start lexer.Type, end lexer.Type, cb func()) {
+func (p *parser) some(start lexer.Type, end lexer.Type, cb func()) *ast.CommentGroup {
 	hasDef := p.skip(start)
 	if !hasDef {
-		return
+		return nil
 	}
 
 	called := false
@@ -178,8 +178,10 @@ func (p *parser) some(start lexer.Type, end lexer.Type, cb func()) {
 
 	if !called {
 		p.error(p.peek(), "expected at least one definition, found %s", p.peek().Kind.String())
-		return
+		return nil
 	}
 
+	comment := p.comment
 	p.next()
+	return comment
 }

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -167,7 +167,7 @@ func (p *parser) parseObjectTypeDefinition(description descriptionWithComment) *
 	def.Name = p.parseName()
 	def.Interfaces = p.parseImplementsInterfaces()
 	def.Directives = p.parseDirectives(true)
-	def.Fields = p.parseFieldsDefinition()
+	def.Fields, def.EndOfDefinitionComment = p.parseFieldsDefinition()
 	return &def
 }
 
@@ -186,12 +186,12 @@ func (p *parser) parseImplementsInterfaces() []string {
 	return types
 }
 
-func (p *parser) parseFieldsDefinition() FieldList {
+func (p *parser) parseFieldsDefinition() (FieldList, *CommentGroup) {
 	var defs FieldList
-	p.some(lexer.BraceL, lexer.BraceR, func() {
+	comment := p.some(lexer.BraceL, lexer.BraceR, func() {
 		defs = append(defs, p.parseFieldDefinition())
 	})
-	return defs
+	return defs, comment
 }
 
 func (p *parser) parseFieldDefinition() *FieldDefinition {
@@ -279,7 +279,7 @@ func (p *parser) parseInterfaceTypeDefinition(description descriptionWithComment
 	def.Name = p.parseName()
 	def.Interfaces = p.parseImplementsInterfaces()
 	def.Directives = p.parseDirectives(true)
-	def.Fields = p.parseFieldsDefinition()
+	def.Fields, def.EndOfDefinitionComment = p.parseFieldsDefinition()
 	return &def
 }
 
@@ -323,16 +323,16 @@ func (p *parser) parseEnumTypeDefinition(description descriptionWithComment) *De
 	def.AfterDescriptionComment = comment
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
-	def.EnumValues = p.parseEnumValuesDefinition()
+	def.EnumValues, def.EndOfDefinitionComment = p.parseEnumValuesDefinition()
 	return &def
 }
 
-func (p *parser) parseEnumValuesDefinition() EnumValueList {
+func (p *parser) parseEnumValuesDefinition() (EnumValueList, *CommentGroup) {
 	var values EnumValueList
-	p.some(lexer.BraceL, lexer.BraceR, func() {
+	comment := p.some(lexer.BraceL, lexer.BraceR, func() {
 		values = append(values, p.parseEnumValueDefinition())
 	})
-	return values
+	return values, comment
 }
 
 func (p *parser) parseEnumValueDefinition() *EnumValueDefinition {
@@ -364,16 +364,16 @@ func (p *parser) parseInputObjectTypeDefinition(description descriptionWithComme
 	def.AfterDescriptionComment = comment
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
-	def.Fields = p.parseInputFieldsDefinition()
+	def.Fields, def.EndOfDefinitionComment = p.parseInputFieldsDefinition()
 	return &def
 }
 
-func (p *parser) parseInputFieldsDefinition() FieldList {
+func (p *parser) parseInputFieldsDefinition() (FieldList, *CommentGroup) {
 	var values FieldList
-	p.some(lexer.BraceL, lexer.BraceR, func() {
+	comment := p.some(lexer.BraceL, lexer.BraceR, func() {
 		values = append(values, p.parseInputValueDef())
 	})
-	return values
+	return values, comment
 }
 
 func (p *parser) parseTypeSystemExtension(doc *SchemaDocument) {
@@ -440,7 +440,7 @@ func (p *parser) parseObjectTypeExtension(comment *CommentGroup) *Definition {
 	def.Name = p.parseName()
 	def.Interfaces = p.parseImplementsInterfaces()
 	def.Directives = p.parseDirectives(true)
-	def.Fields = p.parseFieldsDefinition()
+	def.Fields, def.EndOfDefinitionComment = p.parseFieldsDefinition()
 	if len(def.Interfaces) == 0 && len(def.Directives) == 0 && len(def.Fields) == 0 {
 		p.unexpectedError()
 	}
@@ -456,7 +456,7 @@ func (p *parser) parseInterfaceTypeExtension(comment *CommentGroup) *Definition 
 	def.Kind = Interface
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
-	def.Fields = p.parseFieldsDefinition()
+	def.Fields, def.EndOfDefinitionComment = p.parseFieldsDefinition()
 	if len(def.Directives) == 0 && len(def.Fields) == 0 {
 		p.unexpectedError()
 	}
@@ -489,7 +489,7 @@ func (p *parser) parseEnumTypeExtension(comment *CommentGroup) *Definition {
 	def.Kind = Enum
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
-	def.EnumValues = p.parseEnumValuesDefinition()
+	def.EnumValues, def.EndOfDefinitionComment = p.parseEnumValuesDefinition()
 	if len(def.Directives) == 0 && len(def.EnumValues) == 0 {
 		p.unexpectedError()
 	}
@@ -505,7 +505,7 @@ func (p *parser) parseInputObjectTypeExtension(comment *CommentGroup) *Definitio
 	def.Kind = InputObject
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(false)
-	def.Fields = p.parseInputFieldsDefinition()
+	def.Fields, def.EndOfDefinitionComment = p.parseInputFieldsDefinition()
 	if len(def.Directives) == 0 && len(def.Fields) == 0 {
 		p.unexpectedError()
 	}

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -128,7 +128,7 @@ func (p *parser) parseSchemaDefinition(description descriptionWithComment) *Sche
 	def.AfterDescriptionComment = comment
 	def.Directives = p.parseDirectives(true)
 
-	p.some(lexer.BraceL, lexer.BraceR, func() {
+	def.EndOfDefinitionComment = p.some(lexer.BraceL, lexer.BraceR, func() {
 		def.OperationTypes = append(def.OperationTypes, p.parseOperationTypeDefinition())
 	})
 	return &def
@@ -409,7 +409,7 @@ func (p *parser) parseSchemaExtension(comment *CommentGroup) *SchemaDefinition {
 	def.Position = p.peekPos()
 	def.AfterDescriptionComment = comment
 	def.Directives = p.parseDirectives(true)
-	p.some(lexer.BraceL, lexer.BraceR, func() {
+	def.EndOfDefinitionComment = p.some(lexer.BraceL, lexer.BraceR, func() {
 		def.OperationTypes = append(def.OperationTypes, p.parseOperationTypeDefinition())
 	})
 	if len(def.Directives) == 0 && len(def.OperationTypes) == 0 {

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -73,6 +73,9 @@ func (p *parser) parseSchemaDocument() *SchemaDocument {
 		}
 	}
 
+	// treat end of file comments
+	doc.Comment = p.comment
+
 	return &doc
 }
 

--- a/parser/schema_test.yml
+++ b/parser/schema_test.yml
@@ -23,6 +23,7 @@ object types:
         # World
         # World another
         world: String
+        # end of type comments
       }
     ast: |
       <SchemaDocument>
@@ -36,6 +37,7 @@ object types:
                 Type: String
                 AfterDescriptionComment: "# World\n# World another\n"
             AfterDescriptionComment: "# Hello\n# Hello another\n"
+            EndOfDefinitionComment: "# end of type comments\n"
 
   - name: with comments and description
     input: |
@@ -51,6 +53,8 @@ object types:
         # World after description
         # World after description another
         world: String
+        # end of definition coments
+        # end of definition comments another
       }
     ast: |
       <SchemaDocument>
@@ -68,6 +72,7 @@ object types:
                 AfterDescriptionComment: "# World after description\n# World after description another\n"
             BeforeDescriptionComment: "# Hello\n# Hello another\n"
             AfterDescriptionComment: "# Hello after description\n# Hello after description another\n"
+            EndOfDefinitionComment: "# end of definition coments\n# end of definition comments another\n"
 
   - name: with description
     input: |
@@ -205,7 +210,9 @@ type extensions:
     input: |
       # comment
       extend type Hello {
+        # comment world
         world: String
+        # end of definition comment
       }
     ast: |
       <SchemaDocument>
@@ -217,7 +224,9 @@ type extensions:
             - <FieldDefinition>
                 Name: "world"
                 Type: String
+                AfterDescriptionComment: "# comment world\n"
             AfterDescriptionComment: "# comment\n"
+            EndOfDefinitionComment: "# end of definition comment\n"
 
   - name: without any fields
     input: "extend type Hello implements Greeting"

--- a/parser/schema_test.yml
+++ b/parser/schema_test.yml
@@ -25,6 +25,7 @@ object types:
         world: String
         # end of type comments
       }
+      # end of file comments
     ast: |
       <SchemaDocument>
         Definitions: [Definition]
@@ -38,6 +39,7 @@ object types:
                 AfterDescriptionComment: "# World\n# World another\n"
             AfterDescriptionComment: "# Hello\n# Hello another\n"
             EndOfDefinitionComment: "# end of type comments\n"
+        Comment: "# end of file comments\n"
 
   - name: with comments and description
     input: |

--- a/parser/schema_test.yml
+++ b/parser/schema_test.yml
@@ -347,6 +347,30 @@ schema definition:
                 Operation: Operation("query")
                 Type: "Query"
 
+  - name: with comments and description
+    input: |
+      # before description comment
+      "description"
+      # after description comment
+      schema {
+        # before field comment
+        query: Query
+        # after field comment
+      }
+    ast: |
+      <SchemaDocument>
+        Schema: [SchemaDefinition]
+        - <SchemaDefinition>
+            Description: "description"
+            OperationTypes: [OperationTypeDefinition]
+            - <OperationTypeDefinition>
+                Operation: Operation("query")
+                Type: "Query"
+                Comment: "# before field comment\n"
+            BeforeDescriptionComment: "# before description comment\n"
+            AfterDescriptionComment: "# after description comment\n"
+            EndOfDefinitionComment: "# after field comment\n"
+
 schema extensions:
   - name: simple
     input: |
@@ -361,6 +385,26 @@ schema extensions:
             - <OperationTypeDefinition>
                 Operation: Operation("mutation")
                 Type: "Mutation"
+
+  - name: with comment and description
+    input: |
+      # before extend comment
+       extend schema {
+         # before field comment
+         mutation: Mutation
+         # after field comment
+       }
+    ast: |
+      <SchemaDocument>
+        SchemaExtension: [SchemaDefinition]
+        - <SchemaDefinition>
+            OperationTypes: [OperationTypeDefinition]
+            - <OperationTypeDefinition>
+                Operation: Operation("mutation")
+                Type: "Mutation"
+                Comment: "# before field comment\n"
+            AfterDescriptionComment: "# before extend comment\n"
+            EndOfDefinitionComment: "# after field comment\n"
 
   - name: directive only
     input: "extend schema @directive"


### PR DESCRIPTION
This PR adds support to gqlparser for parsing and formatting end-of-file and end-of-definition comments.

I have:
 - [x] Added tests covering the bug / feature 
 - [x] Updated any relevant documentation
