### PR TITLE
feat(formatter): preserve spaces at the head of comments

### DIFF
--- a/ast/comment.go
+++ b/ast/comment.go
@@ -11,7 +11,7 @@ type Comment struct {
 }
 
 func (c *Comment) Text() string {
-	return strings.TrimSpace(strings.TrimPrefix(c.Value, "#"))
+	return strings.TrimPrefix(c.Value, "#")
 }
 
 type CommentGroup struct {

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -726,5 +726,5 @@ func (f *formatter) FormatComment(comment *ast.Comment) {
 	if comment == nil {
 		return
 	}
-	f.WriteString("# ").WriteString(comment.Text()).WriteNewline()
+	f.WriteString("#").WriteString(comment.Text()).WriteNewline()
 }

--- a/formatter/testdata/baseline/FormatSchemaDocument/comment.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/comment.graphql
@@ -1,0 +1,5 @@
+#no spaces at the head of comment
+# one space at the head of comment
+#  two spaces at the head of comment
+#	one tab at the head of comment
+#		two tabs at the head of comment

--- a/formatter/testdata/source/schema/comment.graphql
+++ b/formatter/testdata/source/schema/comment.graphql
@@ -1,0 +1,5 @@
+#no spaces at the head of comment
+# one space at the head of comment
+#  two spaces at the head of comment
+#	one tab at the head of comment
+#		two tabs at the head of comment


### PR DESCRIPTION
This PR allows the formatter to preserve spaces at the beginning of comments.
Prior to this PR, the formatter would enforce comments to have a single space before the text, thereby removing the indentation of comment strings.

I have:
 - [x] Added tests covering the bug / feature 
 - [x] Updated any relevant documentation
