### PR TITLE
Allow ommitting Directive arguments that are non-null if they have defaults

### DIFF
--- a/validator/schema.go
+++ b/validator/schema.go
@@ -382,7 +382,7 @@ func validateDirectives(schema *Schema, dirs DirectiveList, location DirectiveLo
 			}
 		}
 		for _, schemaArg := range dirDefinition.Arguments {
-			if schemaArg.Type.NonNull {
+			if schemaArg.Type.NonNull && schemaArg.DefaultValue == nil {
 				if arg := dir.Arguments.ForName(schemaArg.Name); arg == nil || arg.Value.Kind == NullValue {
 					return gqlerror.ErrorPosf(dir.Position, "Argument %s for directive %s cannot be null.", schemaArg.Name, dir.Name)
 				}


### PR DESCRIPTION
Allow omitting Directive arguments that are Non-null AND have defaults. 

Fix #269 

Follow-up to #258 : Directives should validate argument names and non-null fields.

### Minimal graphql.schema and models to reproduce
```
type AircraftManufacturer
  @join__type(graph: AIRCRAFT, key: "uuid")
{
  uuid: ID!
  name: String!
}
```
The directive definition of:
```graphql
directive @join__type(
  graph: Graph!,
  key: FieldSet,
  extension: Boolean = false,
  resolvable: Boolean = true,
  isInterfaceObject: Boolean = false
) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
```
so the argument in question (`extension`) is non-nullable but has a default so still isn't required.


Signed-off-by: Steve Coffman <steve@khanacademy.org>
