### PR TITLE
Add directive limit to prevent overloading

### DIFF
--- a/parser/query.go
+++ b/parser/query.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"fmt"
+
 	"github.com/vektah/gqlparser/v2/lexer"
 
 	//nolint:revive
@@ -315,12 +317,21 @@ func (p *parser) parseObjectField(isConst bool) *ChildValue {
 
 func (p *parser) parseDirectives(isConst bool) []*Directive {
 	var directives []*Directive
+	directiveCount := 0
+	maxDirectiveLimit := 10 // Define a reasonable limit
 
 	for p.peek().Kind == lexer.At {
 		if p.err != nil {
 			break
 		}
 		directives = append(directives, p.parseDirective(isConst))
+		directiveCount++
+
+		// Set an internal parser error if the directive limit is exceeded
+		if directiveCount > maxDirectiveLimit {
+			p.err = fmt.Errorf("exceeded directive limit of %d", maxDirectiveLimit)
+			break // Stop processing further directives
+		}
 	}
 	return directives
 }


### PR DESCRIPTION
I have noticed a similar issue to the one in the graphql-java lib (see **CVE-2022-37734**) - There is no limit on the number of directives that can be given as input inside the GraphQL query.

Adding a large amount of non-existing directives can significantly increase the query's processing time and response size; hence, sending similar requests with the payload simultaneously can cause a DoS condition on the server.

Let's say that you have a valid GraphQL query"

```
query {
  user {
    name
  }
}

```
modify it so it will have many non-existing directives, e.g.:
```

query {
  user @aa @aa @aa ... {
    name
  }
} 
```

Replace ... with as many @aa as you need. The more you add, the larger the response size and time processed.

As a fix I limited the number of allowed directives to 10, but this can be changed of course.

Once the issue is fixed, could you add an advisory under the **security tab**? 

The CVE ID is  **CVE-2023-49559**