### PR TITLE
gqlerror: implement List.Unwrap

### DIFF
--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -106,6 +106,14 @@ func (errs List) As(target interface{}) bool {
 	return false
 }
 
+func (errs List) Unwrap() []error {
+	l := make([]error, len(errs))
+	for i, err := range errs {
+		l[i] = err
+	}
+	return l
+}
+
 func WrapPath(path ast.Path, err error) *Error {
 	if err == nil {
 		return nil


### PR DESCRIPTION
Go 1.20 has added a new Unwrap method for error values holding multiple errors. Implement this method as that errors.Is/As work as expected.