### PR TITLE
Token limit fix CVE-2023-49559

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -105,7 +105,7 @@ func (p *parser) next() lexer.Token {
 	}
 	// Increment the token count before reading the next token
 	p.tokenCount++
-	if p.tokenCount > p.maxTokenLimit {
+	if p.maxTokenLimit != 0 && p.tokenCount > p.maxTokenLimit {
 		p.err = fmt.Errorf("exceeded token limit of %d", p.maxTokenLimit)
 		return p.prev
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/vektah/gqlparser/v2/ast"
@@ -20,6 +21,9 @@ type parser struct {
 
 	comment          *ast.CommentGroup
 	commentConsuming bool
+
+	tokenCount    int
+	maxTokenLimit int
 }
 
 func (p *parser) consumeComment() (*ast.Comment, bool) {
@@ -93,6 +97,12 @@ func (p *parser) error(tok lexer.Token, format string, args ...interface{}) {
 
 func (p *parser) next() lexer.Token {
 	if p.err != nil {
+		return p.prev
+	}
+	// Increment the token count before reading the next token
+	p.tokenCount++
+	if p.tokenCount > p.maxTokenLimit {
+		p.err = fmt.Errorf("exceeded token limit of %d", p.maxTokenLimit)
 		return p.prev
 	}
 	if p.peeked {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -26,6 +26,10 @@ type parser struct {
 	maxTokenLimit int
 }
 
+func (p *parser) SetMaxTokenLimit(maxToken int) {
+	p.maxTokenLimit = maxToken
+}
+
 func (p *parser) consumeComment() (*ast.Comment, bool) {
 	if p.err != nil {
 		return nil, false

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -166,5 +166,8 @@ func TestParserUtils(t *testing.T) {
 }
 
 func newParser(input string) parser {
-	return parser{lexer: lexer.New(&ast.Source{Input: input, Name: "input.graphql"})}
+	return parser{
+		lexer:         lexer.New(&ast.Source{Input: input, Name: "input.graphql"}),
+		maxTokenLimit: 15000, // 15000 is the default value
+	}
 }

--- a/parser/query.go
+++ b/parser/query.go
@@ -1,17 +1,15 @@
 package parser
 
 import (
-	"fmt"
-
 	"github.com/vektah/gqlparser/v2/lexer"
-
 	//nolint:revive
 	. "github.com/vektah/gqlparser/v2/ast"
 )
 
 func ParseQuery(source *Source) (*QueryDocument, error) {
 	p := parser{
-		lexer: lexer.New(source),
+		lexer:         lexer.New(source),
+		maxTokenLimit: 15000, // 15000 is the default value
 	}
 	return p.parseQueryDocument(), p.err
 }
@@ -317,21 +315,13 @@ func (p *parser) parseObjectField(isConst bool) *ChildValue {
 
 func (p *parser) parseDirectives(isConst bool) []*Directive {
 	var directives []*Directive
-	directiveCount := 0
-	maxDirectiveLimit := 10 // Define a reasonable limit
 
 	for p.peek().Kind == lexer.At {
 		if p.err != nil {
 			break
 		}
 		directives = append(directives, p.parseDirective(isConst))
-		directiveCount++
 
-		// Set an internal parser error if the directive limit is exceeded
-		if directiveCount > maxDirectiveLimit {
-			p.err = fmt.Errorf("exceeded directive limit of %d", maxDirectiveLimit)
-			break // Stop processing further directives
-		}
 	}
 	return directives
 }

--- a/parser/query.go
+++ b/parser/query.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"fmt"
+
 	"github.com/vektah/gqlparser/v2/lexer"
 
 	//nolint:revive
@@ -315,12 +317,21 @@ func (p *parser) parseObjectField(isConst bool) *ChildValue {
 
 func (p *parser) parseDirectives(isConst bool) []*Directive {
 	var directives []*Directive
+	directiveCount := 0
+	maxDirectiveLimit := 10 // Define a reasonable limit
 
 	for p.peek().Kind == lexer.At {
 		if p.err != nil {
 			break
 		}
 		directives = append(directives, p.parseDirective(isConst))
+		directiveCount++
+
+		// Set an internal parser error if the directive limit is exceeded
+		if directiveCount > maxDirectiveLimit {
+			p.err = fmt.Errorf("exceeded directive limit of %d", maxDirectiveLimit)
+			break // Stop processing further directives
+		}
 	}
 	return directives
 }

--- a/parser/query.go
+++ b/parser/query.go
@@ -9,7 +9,7 @@ import (
 func ParseQuery(source *Source) (*QueryDocument, error) {
 	p := parser{
 		lexer:         lexer.New(source),
-		maxTokenLimit: 15000, // 15000 is the default value
+		maxTokenLimit: 0, // 0 is the default value
 	}
 	return p.parseQueryDocument(), p.err
 }

--- a/parser/query.go
+++ b/parser/query.go
@@ -321,7 +321,6 @@ func (p *parser) parseDirectives(isConst bool) []*Directive {
 			break
 		}
 		directives = append(directives, p.parseDirective(isConst))
-
 	}
 	return directives
 }

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -20,7 +20,8 @@ func ParseSchemas(inputs ...*Source) (*SchemaDocument, error) {
 
 func ParseSchema(source *Source) (*SchemaDocument, error) {
 	p := parser{
-		lexer: lexer.New(source),
+		lexer:         lexer.New(source),
+		maxTokenLimit: 15000, // default value
 	}
 	sd, err := p.parseSchemaDocument(), p.err
 	if err != nil {


### PR DESCRIPTION
Hi,

I added a default token limit value of 15000 and a token count inside next() function in parser.go

the limit should be configured by callers of the parser (i.e. gqlgen, genqlient, etc.).  - Can you assist with that?
