### PR TITLE
Disallow empty parens (#292).

### DIFF
--- a/parser/query.go
+++ b/parser/query.go
@@ -83,7 +83,7 @@ func (p *parser) parseOperationType() Operation {
 
 func (p *parser) parseVariableDefinitions() VariableDefinitionList {
 	var defs []*VariableDefinition
-	p.many(lexer.ParenL, lexer.ParenR, func() {
+	p.some(lexer.ParenL, lexer.ParenR, func() {
 		defs = append(defs, p.parseVariableDefinition())
 	})
 
@@ -167,7 +167,7 @@ func (p *parser) parseField() *Field {
 
 func (p *parser) parseArguments(isConst bool) ArgumentList {
 	var arguments ArgumentList
-	p.many(lexer.ParenL, lexer.ParenR, func() {
+	p.some(lexer.ParenL, lexer.ParenR, func() {
 		arguments = append(arguments, p.parseArgument(isConst))
 	})
 

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -80,6 +80,15 @@ object types:
       message: 'Name "__id" must not begin with "__", which is reserved by GraphQL introspection.'
       locations: [{line: 2, column: 3}]
 
+  - name: field argument list must not be empty
+    input: |
+      type FooBar {
+        foo(): ID
+      }
+    error:
+      message: 'expected at least one definition, found )'
+      locations: [{line: 2, column: 7}]
+
   - name: check reserved names on type field argument
     input: |
       type FooBar {

--- a/validator/spec/EmptyParens.spec.yml
+++ b/validator/spec/EmptyParens.spec.yml
@@ -1,0 +1,26 @@
+- name: Empty variables list
+  schema: 0
+  query: |
+    query foo(){
+      dog {
+        __typename
+      }
+    }
+
+  errors:
+    - message: "expected at least one definition, found )"
+      locations:
+      - {line: 1, column: 11}
+- name: Empty arguments list
+  schema: 0
+  query: |
+    query foo{
+      dog() {
+        __typename
+      }
+    }
+
+  errors:
+    - message: "expected at least one definition, found )"
+      locations:
+      - {line: 2, column: 7}


### PR DESCRIPTION
This disallows empty parens in variables and argument lists in operations according to GQL spec. See #292.

I have:
 - [x] Added tests covering the bug / feature 
 - (N/A) Updated any relevant documentation
