### PR TITLE
WithBuiltin FormatterOption added

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -33,6 +33,13 @@ func WithComments() FormatterOption {
 	}
 }
 
+// WithBuiltin includes builtin fields/directives/etc from the source/AST in the formatted output.
+func WithBuiltin() FormatterOption {
+	return func(f *formatter) {
+		f.emitBuiltin = true
+	}
+}
+
 func NewFormatter(w io.Writer, options ...FormatterOption) Formatter {
 	f := &formatter{
 		indent: "\t",


### PR DESCRIPTION
Added WithBuiltin option for formatter.
Reason: emitBuiltin exists and used, but no chance enable it outside. We need it :)

I have:
 - [ ] Added tests covering the bug / feature 
 - [ ] Updated any relevant documentation
