### PR TITLE
validator: better error message when InputObject is not a map

### DIFF
--- a/validator/vars.go
+++ b/validator/vars.go
@@ -180,7 +180,7 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) (reflec
 		return val, gqlerror.ErrorPathf(v.path, "cannot use %s as %s", kind.String(), typ.NamedType)
 	case ast.InputObject:
 		if val.Kind() != reflect.Map {
-			return val, gqlerror.ErrorPathf(v.path, "must be a %s", def.Name)
+			return val, gqlerror.ErrorPathf(v.path, "must be a %s, not a %s", def.Name, val.Kind())
 		}
 
 		// check for unknown fields


### PR DESCRIPTION
I lost quite a bit of time understanding why my InputObject was not a <something>, because I was sending it as a JSON marshaled string in the GQL request instead of in JSON directly.

That's why I thought it would be worth to add this PR :)

Best,