### PR TITLE
validator: make rules exported and allow custom set of rules for Validate

### DIFF
--- a/validator/imported_test.go
+++ b/validator/imported_test.go
@@ -11,10 +11,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/gqlerror"
-	"gopkg.in/yaml.v2"
 )
 
 type Spec struct {

--- a/validator/rules/fields_on_correct_type.go
+++ b/validator/rules/fields_on_correct_type.go
@@ -28,7 +28,7 @@ var FieldsOnCorrectTypeRule = Rule{
 			}
 
 			addError(
-				Message(message),
+				Message("%s", message),
 				At(field.Position),
 			)
 		})

--- a/validator/rules/fields_on_correct_type.go
+++ b/validator/rules/fields_on_correct_type.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"fmt"
@@ -11,8 +11,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("FieldsOnCorrectType", func(observers *Events, addError AddErrFunc) {
+var FieldsOnCorrectTypeRule = Rule{
+	Name: "FieldsOnCorrectType",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnField(func(walker *Walker, field *ast.Field) {
 			if field.ObjectDefinition == nil || field.Definition != nil {
 				return
@@ -31,10 +32,14 @@ func init() {
 				At(field.Position),
 			)
 		})
-	})
+	},
 }
 
-// Go through all of the implementations of type, as well as the interfaces
+func init() {
+	AddRule(FieldsOnCorrectTypeRule.Name, FieldsOnCorrectTypeRule.RuleFunc)
+}
+
+// Go through all the implementations of type, as well as the interfaces
 // that they implement. If any of those types include the provided field,
 // suggest them, sorted by how often the type is referenced,  starting
 // with Interfaces.

--- a/validator/rules/fragments_on_composite_types.go
+++ b/validator/rules/fragments_on_composite_types.go
@@ -21,7 +21,7 @@ var FragmentsOnCompositeTypesRule = Rule{
 			message := fmt.Sprintf(`Fragment cannot condition on non composite type "%s".`, inlineFragment.TypeCondition)
 
 			addError(
-				Message(message),
+				Message("%s", message),
 				At(inlineFragment.Position),
 			)
 		})
@@ -34,7 +34,7 @@ var FragmentsOnCompositeTypesRule = Rule{
 			message := fmt.Sprintf(`Fragment "%s" cannot condition on non composite type "%s".`, fragment.Name, fragment.TypeCondition)
 
 			addError(
-				Message(message),
+				Message("%s", message),
 				At(fragment.Position),
 			)
 		})

--- a/validator/rules/fragments_on_composite_types.go
+++ b/validator/rules/fragments_on_composite_types.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"fmt"
@@ -9,8 +9,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("FragmentsOnCompositeTypes", func(observers *Events, addError AddErrFunc) {
+var FragmentsOnCompositeTypesRule = Rule{
+	Name: "FragmentsOnCompositeTypes",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnInlineFragment(func(walker *Walker, inlineFragment *ast.InlineFragment) {
 			fragmentType := walker.Schema.Types[inlineFragment.TypeCondition]
 			if fragmentType == nil || fragmentType.IsCompositeType() {
@@ -37,5 +38,9 @@ func init() {
 				At(fragment.Position),
 			)
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(FragmentsOnCompositeTypesRule.Name, FragmentsOnCompositeTypesRule.RuleFunc)
 }

--- a/validator/rules/known_argument_names.go
+++ b/validator/rules/known_argument_names.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("KnownArgumentNames", func(observers *Events, addError AddErrFunc) {
+var KnownArgumentNamesRule = Rule{
+	Name: "KnownArgumentNames",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		// A GraphQL field is only valid if all supplied arguments are defined by that field.
 		observers.OnField(func(walker *Walker, field *ast.Field) {
 			if field.Definition == nil || field.ObjectDefinition == nil {
@@ -55,5 +56,9 @@ func init() {
 				)
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(KnownArgumentNamesRule.Name, KnownArgumentNamesRule.RuleFunc)
 }

--- a/validator/rules/known_directives.go
+++ b/validator/rules/known_directives.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("KnownDirectives", func(observers *Events, addError AddErrFunc) {
+var KnownDirectivesRule = Rule{
+	Name: "KnownDirectives",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		type mayNotBeUsedDirective struct {
 			Name   string
 			Line   int
@@ -45,5 +46,9 @@ func init() {
 				seen[tmp] = true
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(KnownDirectivesRule.Name, KnownDirectivesRule.RuleFunc)
 }

--- a/validator/rules/known_fragment_names.go
+++ b/validator/rules/known_fragment_names.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("KnownFragmentNames", func(observers *Events, addError AddErrFunc) {
+var KnownFragmentNamesRule = Rule{
+	Name: "KnownFragmentNames",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnFragmentSpread(func(walker *Walker, fragmentSpread *ast.FragmentSpread) {
 			if fragmentSpread.Definition == nil {
 				addError(
@@ -17,5 +18,9 @@ func init() {
 				)
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(KnownFragmentNamesRule.Name, KnownFragmentNamesRule.RuleFunc)
 }

--- a/validator/rules/known_root_type.go
+++ b/validator/rules/known_root_type.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"fmt"
@@ -9,8 +9,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("KnownRootType", func(observers *Events, addError AddErrFunc) {
+var KnownRootTypeRule = Rule{
+	Name: "KnownRootType",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		// A query's root must be a valid type.  Surprisingly, this isn't
 		// checked anywhere else!
 		observers.OnOperation(func(walker *Walker, operation *ast.OperationDefinition) {
@@ -33,5 +34,9 @@ func init() {
 					At(operation.Position))
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(KnownRootTypeRule.Name, KnownRootTypeRule.RuleFunc)
 }

--- a/validator/rules/known_type_names.go
+++ b/validator/rules/known_type_names.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("KnownTypeNames", func(observers *Events, addError AddErrFunc) {
+var KnownTypeNamesRule = Rule{
+	Name: "KnownTypeNames",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnVariable(func(walker *Walker, variable *ast.VariableDefinition) {
 			typeName := variable.Type.Name()
 			typdef := walker.Schema.Types[typeName]
@@ -57,5 +58,9 @@ func init() {
 				At(fragment.Position),
 			)
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(KnownTypeNamesRule.Name, KnownTypeNamesRule.RuleFunc)
 }

--- a/validator/rules/lone_anonymous_operation.go
+++ b/validator/rules/lone_anonymous_operation.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("LoneAnonymousOperation", func(observers *Events, addError AddErrFunc) {
+var LoneAnonymousOperationRule = Rule{
+	Name: "LoneAnonymousOperation",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnOperation(func(walker *Walker, operation *ast.OperationDefinition) {
 			if operation.Name == "" && len(walker.Document.Operations) > 1 {
 				addError(
@@ -17,5 +18,9 @@ func init() {
 				)
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(LoneAnonymousOperationRule.Name, LoneAnonymousOperationRule.RuleFunc)
 }

--- a/validator/rules/no_fragment_cycles.go
+++ b/validator/rules/no_fragment_cycles.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"fmt"
@@ -10,8 +10,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("NoFragmentCycles", func(observers *Events, addError AddErrFunc) {
+var NoFragmentCyclesRule = Rule{
+	Name: "NoFragmentCycles",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		visitedFrags := make(map[string]bool)
 
 		observers.OnFragment(func(walker *Walker, fragment *ast.FragmentDefinition) {
@@ -67,7 +68,11 @@ func init() {
 
 			recursive(fragment)
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(NoFragmentCyclesRule.Name, NoFragmentCyclesRule.RuleFunc)
 }
 
 func getFragmentSpreads(node ast.SelectionSet) []*ast.FragmentSpread {

--- a/validator/rules/no_undefined_variables.go
+++ b/validator/rules/no_undefined_variables.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("NoUndefinedVariables", func(observers *Events, addError AddErrFunc) {
+var NoUndefinedVariablesRule = Rule{
+	Name: "NoUndefinedVariables",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnValue(func(walker *Walker, value *ast.Value) {
 			if walker.CurrentOperation == nil || value.Kind != ast.Variable || value.VariableDefinition != nil {
 				return
@@ -26,5 +27,9 @@ func init() {
 				)
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(NoUndefinedVariablesRule.Name, NoUndefinedVariablesRule.RuleFunc)
 }

--- a/validator/rules/no_unused_fragments.go
+++ b/validator/rules/no_unused_fragments.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("NoUnusedFragments", func(observers *Events, addError AddErrFunc) {
+var NoUnusedFragmentsRule = Rule{
+	Name: "NoUnusedFragments",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		inFragmentDefinition := false
 		fragmentNameUsed := make(map[string]bool)
 
@@ -27,5 +28,9 @@ func init() {
 				)
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(NoUnusedFragmentsRule.Name, NoUnusedFragmentsRule.RuleFunc)
 }

--- a/validator/rules/no_unused_variables.go
+++ b/validator/rules/no_unused_variables.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("NoUnusedVariables", func(observers *Events, addError AddErrFunc) {
+var NoUnusedVariablesRule = Rule{
+	Name: "NoUnusedVariables",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnOperation(func(walker *Walker, operation *ast.OperationDefinition) {
 			for _, varDef := range operation.VariableDefinitions {
 				if varDef.Used {
@@ -28,5 +29,9 @@ func init() {
 				}
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(NoUnusedVariablesRule.Name, NoUnusedVariablesRule.RuleFunc)
 }

--- a/validator/rules/overlapping_fields_can_be_merged.go
+++ b/validator/rules/overlapping_fields_can_be_merged.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"bytes"
@@ -11,8 +11,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("OverlappingFieldsCanBeMerged", func(observers *Events, addError AddErrFunc) {
+var OverlappingFieldsCanBeMergedRule = Rule{
+	Name: "OverlappingFieldsCanBeMerged",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		/**
 		 * Algorithm:
 		 *
@@ -41,7 +42,7 @@ func init() {
 		 *
 		 * D) When comparing "between" a set of fields and a referenced fragment, first
 		 * a comparison is made between each field in the original set of fields and
-		 * each field in the the referenced set of fields.
+		 * each field in the referenced set of fields.
 		 *
 		 * E) Also, if any fragment is referenced in the referenced selection set,
 		 * then a comparison is made "between" the original set of fields and the
@@ -104,7 +105,11 @@ func init() {
 				conflict.addFieldsConflictMessage(addError)
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(OverlappingFieldsCanBeMergedRule.Name, OverlappingFieldsCanBeMergedRule.RuleFunc)
 }
 
 type pairSet struct {

--- a/validator/rules/overlapping_fields_can_be_merged_test.go
+++ b/validator/rules/overlapping_fields_can_be_merged_test.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"testing"

--- a/validator/rules/possible_fragment_spreads.go
+++ b/validator/rules/possible_fragment_spreads.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("PossibleFragmentSpreads", func(observers *Events, addError AddErrFunc) {
+var PossibleFragmentSpreadsRule = Rule{
+	Name: "PossibleFragmentSpreads",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		validate := func(walker *Walker, parentDef *ast.Definition, fragmentName string, emitError func()) {
 			if parentDef == nil {
 				return
@@ -65,5 +66,9 @@ func init() {
 				)
 			})
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(PossibleFragmentSpreadsRule.Name, PossibleFragmentSpreadsRule.RuleFunc)
 }

--- a/validator/rules/provided_required_arguments.go
+++ b/validator/rules/provided_required_arguments.go
@@ -1,14 +1,14 @@
-package validator
+package rules
 
 import (
-	"github.com/vektah/gqlparser/v2/ast"
-
 	//nolint:revive // Validator rules each use dot imports for convenience.
+	"github.com/vektah/gqlparser/v2/ast"
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("ProvidedRequiredArguments", func(observers *Events, addError AddErrFunc) {
+var ProvidedRequiredArgumentsRule = Rule{
+	Name: "ProvidedRequiredArguments",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnField(func(walker *Walker, field *ast.Field) {
 			if field.Definition == nil {
 				return
@@ -60,5 +60,9 @@ func init() {
 				)
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(ProvidedRequiredArgumentsRule.Name, ProvidedRequiredArgumentsRule.RuleFunc)
 }

--- a/validator/rules/scalar_leafs.go
+++ b/validator/rules/scalar_leafs.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("ScalarLeafs", func(observers *Events, addError AddErrFunc) {
+var ScalarLeafsRule = Rule{
+	Name: "ScalarLeafs",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnField(func(walker *Walker, field *ast.Field) {
 			if field.Definition == nil {
 				return
@@ -34,5 +35,9 @@ func init() {
 				)
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(ScalarLeafsRule.Name, ScalarLeafsRule.RuleFunc)
 }

--- a/validator/rules/single_field_subscriptions.go
+++ b/validator/rules/single_field_subscriptions.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"strconv"
@@ -10,8 +10,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("SingleFieldSubscriptions", func(observers *Events, addError AddErrFunc) {
+var SingleFieldSubscriptionsRule = Rule{
+	Name: "SingleFieldSubscriptions",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnOperation(func(walker *Walker, operation *ast.OperationDefinition) {
 			if walker.Schema.Subscription == nil || operation.Operation != ast.Subscription {
 				return
@@ -40,7 +41,11 @@ func init() {
 				}
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(SingleFieldSubscriptionsRule.Name, SingleFieldSubscriptionsRule.RuleFunc)
 }
 
 type topField struct {

--- a/validator/rules/unique_argument_names.go
+++ b/validator/rules/unique_argument_names.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("UniqueArgumentNames", func(observers *Events, addError AddErrFunc) {
+var UniqueArgumentNamesRule = Rule{
+	Name: "UniqueArgumentNames",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnField(func(walker *Walker, field *ast.Field) {
 			checkUniqueArgs(field.Arguments, addError)
 		})
@@ -16,7 +17,11 @@ func init() {
 		observers.OnDirective(func(walker *Walker, directive *ast.Directive) {
 			checkUniqueArgs(directive.Arguments, addError)
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(UniqueArgumentNamesRule.Name, UniqueArgumentNamesRule.RuleFunc)
 }
 
 func checkUniqueArgs(args ast.ArgumentList, addError AddErrFunc) {

--- a/validator/rules/unique_directives_per_location.go
+++ b/validator/rules/unique_directives_per_location.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("UniqueDirectivesPerLocation", func(observers *Events, addError AddErrFunc) {
+var UniqueDirectivesPerLocationRule = Rule{
+	Name: "UniqueDirectivesPerLocation",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnDirectiveList(func(walker *Walker, directives []*ast.Directive) {
 			seen := map[string]bool{}
 
@@ -22,5 +23,9 @@ func init() {
 				seen[dir.Name] = true
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(UniqueDirectivesPerLocationRule.Name, UniqueDirectivesPerLocationRule.RuleFunc)
 }

--- a/validator/rules/unique_fragment_names.go
+++ b/validator/rules/unique_fragment_names.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("UniqueFragmentNames", func(observers *Events, addError AddErrFunc) {
+var UniqueFragmentNamesRule = Rule{
+	Name: "UniqueFragmentNames",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		seenFragments := map[string]bool{}
 
 		observers.OnFragment(func(walker *Walker, fragment *ast.FragmentDefinition) {
@@ -20,5 +21,9 @@ func init() {
 			}
 			seenFragments[fragment.Name] = true
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(UniqueFragmentNamesRule.Name, UniqueFragmentNamesRule.RuleFunc)
 }

--- a/validator/rules/unique_input_field_names.go
+++ b/validator/rules/unique_input_field_names.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("UniqueInputFieldNames", func(observers *Events, addError AddErrFunc) {
+var UniqueInputFieldNamesRule = Rule{
+	Name: "UniqueInputFieldNames",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnValue(func(walker *Walker, value *ast.Value) {
 			if value.Kind != ast.ObjectValue {
 				return
@@ -25,5 +26,9 @@ func init() {
 				seen[field.Name] = true
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(UniqueInputFieldNamesRule.Name, UniqueInputFieldNamesRule.RuleFunc)
 }

--- a/validator/rules/unique_operation_names.go
+++ b/validator/rules/unique_operation_names.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("UniqueOperationNames", func(observers *Events, addError AddErrFunc) {
+var UniqueOperationNamesRule = Rule{
+	Name: "UniqueOperationNames",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		seen := map[string]bool{}
 
 		observers.OnOperation(func(walker *Walker, operation *ast.OperationDefinition) {
@@ -20,5 +21,9 @@ func init() {
 			}
 			seen[operation.Name] = true
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(UniqueOperationNamesRule.Name, UniqueOperationNamesRule.RuleFunc)
 }

--- a/validator/rules/unique_variable_names.go
+++ b/validator/rules/unique_variable_names.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("UniqueVariableNames", func(observers *Events, addError AddErrFunc) {
+var UniqueVariableNamesRule = Rule{
+	Name: "UniqueVariableNames",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnOperation(func(walker *Walker, operation *ast.OperationDefinition) {
 			seen := map[string]int{}
 			for _, def := range operation.VariableDefinitions {
@@ -22,5 +23,9 @@ func init() {
 				seen[def.Variable]++
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(UniqueVariableNamesRule.Name, UniqueVariableNamesRule.RuleFunc)
 }

--- a/validator/rules/values_of_correct_type.go
+++ b/validator/rules/values_of_correct_type.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"errors"
@@ -11,8 +11,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("ValuesOfCorrectType", func(observers *Events, addError AddErrFunc) {
+var ValuesOfCorrectTypeRule = Rule{
+	Name: "ValuesOfCorrectType",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnValue(func(walker *Walker, value *ast.Value) {
 			if value.Definition == nil || value.ExpectedType == nil {
 				return
@@ -134,7 +135,11 @@ func init() {
 				panic(fmt.Errorf("unhandled %T", value))
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(ValuesOfCorrectTypeRule.Name, ValuesOfCorrectTypeRule.RuleFunc)
 }
 
 func unexpectedTypeMessage(addError AddErrFunc, v *ast.Value) {

--- a/validator/rules/variables_are_input_types.go
+++ b/validator/rules/variables_are_input_types.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("VariablesAreInputTypes", func(observers *Events, addError AddErrFunc) {
+var VariablesAreInputTypesRule = Rule{
+	Name: "VariablesAreInputTypes",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnOperation(func(walker *Walker, operation *ast.OperationDefinition) {
 			for _, def := range operation.VariableDefinitions {
 				if def.Definition == nil {
@@ -26,5 +27,9 @@ func init() {
 				}
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(VariablesAreInputTypesRule.Name, VariablesAreInputTypesRule.RuleFunc)
 }

--- a/validator/rules/variables_in_allowed_position.go
+++ b/validator/rules/variables_in_allowed_position.go
@@ -1,4 +1,4 @@
-package validator
+package rules
 
 import (
 	"github.com/vektah/gqlparser/v2/ast"
@@ -7,8 +7,9 @@ import (
 	. "github.com/vektah/gqlparser/v2/validator"
 )
 
-func init() {
-	AddRule("VariablesInAllowedPosition", func(observers *Events, addError AddErrFunc) {
+var VariablesInAllowedPositionRule = Rule{
+	Name: "VariablesInAllowedPosition",
+	RuleFunc: func(observers *Events, addError AddErrFunc) {
 		observers.OnValue(func(walker *Walker, value *ast.Value) {
 			if value.Kind != ast.Variable || value.ExpectedType == nil || value.VariableDefinition == nil || walker.CurrentOperation == nil {
 				return
@@ -36,5 +37,9 @@ func init() {
 				)
 			}
 		})
-	})
+	},
+}
+
+func init() {
+	AddRule(VariablesInAllowedPositionRule.Name, VariablesInAllowedPositionRule.RuleFunc)
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -8,22 +8,26 @@ import (
 
 type AddErrFunc func(options ...ErrorOption)
 
-type ruleFunc func(observers *Events, addError AddErrFunc)
+type RuleFunc func(observers *Events, addError AddErrFunc)
 
-type rule struct {
-	name string
-	rule ruleFunc
+type Rule struct {
+	Name     string
+	RuleFunc RuleFunc
 }
 
-var rules []rule
+var specifiedRules []Rule
 
-// addRule to rule set.
+// AddRule adds rule to the rule set.
 // f is called once each time `Validate` is executed.
-func AddRule(name string, f ruleFunc) {
-	rules = append(rules, rule{name: name, rule: f})
+func AddRule(name string, ruleFunc RuleFunc) {
+	specifiedRules = append(specifiedRules, Rule{Name: name, RuleFunc: ruleFunc})
 }
 
-func Validate(schema *Schema, doc *QueryDocument) gqlerror.List {
+func Validate(schema *Schema, doc *QueryDocument, rules ...Rule) gqlerror.List {
+	if rules == nil {
+		rules = specifiedRules
+	}
+
 	var errs gqlerror.List
 	if schema == nil {
 		errs = append(errs, gqlerror.Errorf("cannot validate as Schema is nil"))
@@ -37,9 +41,9 @@ func Validate(schema *Schema, doc *QueryDocument) gqlerror.List {
 	observers := &Events{}
 	for i := range rules {
 		rule := rules[i]
-		rule.rule(observers, func(options ...ErrorOption) {
+		rule.RuleFunc(observers, func(options ...ErrorOption) {
 			err := &gqlerror.Error{
-				Rule: rule.name,
+				Rule: rule.Name,
 			}
 			for _, o := range options {
 				o(err)

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -141,18 +141,17 @@ func TestNoUnusedVariables(t *testing.T) {
 }
 
 func TestCustomRuleSet(t *testing.T) {
-
 	someRule := validator.Rule{
 		Name: "SomeRule",
 		RuleFunc: func(observers *validator.Events, addError validator.AddErrFunc) {
-			addError(validator.Message("some error message"))
+			addError(validator.Message("%s", "some error message"))
 		},
 	}
 
 	someOtherRule := validator.Rule{
 		Name: "SomeOtherRule",
 		RuleFunc: func(observers *validator.Events, addError validator.AddErrFunc) {
-			addError(validator.Message("some other error message"))
+			addError(validator.Message("%s", "some other error message"))
 		},
 	}
 

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/parser"
@@ -137,4 +138,44 @@ func TestNoUnusedVariables(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, validator.Validate(s, q))
 	})
+}
+
+func TestCustomRuleSet(t *testing.T) {
+
+	someRule := validator.Rule{
+		Name: "SomeRule",
+		RuleFunc: func(observers *validator.Events, addError validator.AddErrFunc) {
+			addError(validator.Message("some error message"))
+		},
+	}
+
+	someOtherRule := validator.Rule{
+		Name: "SomeOtherRule",
+		RuleFunc: func(observers *validator.Events, addError validator.AddErrFunc) {
+			addError(validator.Message("some other error message"))
+		},
+	}
+
+	s := gqlparser.MustLoadSchema(
+		&ast.Source{
+			Name: "graph/schema.graphqls",
+			Input: `
+	type Query {
+		bar: String!
+	}
+	`, BuiltIn: false},
+	)
+
+	q, err := parser.ParseQuery(&ast.Source{
+		Name: "SomeQuery",
+		Input: `
+			query Foo($flag: Boolean!) {
+				...Bar
+			}
+		`})
+	require.NoError(t, err)
+	errList := validator.Validate(s, q, []validator.Rule{someRule, someOtherRule}...)
+	require.Len(t, errList, 2)
+	require.Equal(t, "some error message", errList[0].Message)
+	require.Equal(t, "some other error message", errList[1].Message)
 }


### PR DESCRIPTION
validator.Validate function uses predefined set of rules, which are populated during package initialisation. While it is possible to add custom rules via AddRule, it is not possible to have completely customised set of rules (e.g. if someone wants to delete or replace some predefined rule). The javascript implementation allows to pass custom set of rules and falls back to the default set only if the parameter is null (https://github.com/graphql/graphql-js/blob/bd2fe71d2a7ca8619ec71bae919692ce61e10958/src/validation/validate.ts#L40). This PR converts every rule to the package-level variable and allows to pass custom set of rules to the Validate function as varargs. It also falls back to predefined set of rules for the backward compatibility, so that none of the existing code is broken. With that change validation can be customized: 
```
errList := validator.Validate(s, q, []validator.Rule{rules.FieldsOnCorrectTypeRule, rules.VariablesInAllowedPositionRule}...)
```
Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature 
 - [ ] Updated any relevant documentation
