### PR TITLE
Add an option to format GQL without description

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -40,6 +40,13 @@ func WithBuiltin() FormatterOption {
 	}
 }
 
+// WithoutDescription excludes GQL description from the source/AST in the formatted output.
+func WithoutDescription() FormatterOption {
+	return func(f *formatter) {
+		f.omitDescription = true
+	}
+}
+
 func NewFormatter(w io.Writer, options ...FormatterOption) Formatter {
 	f := &formatter{
 		indent: "\t",
@@ -54,10 +61,11 @@ func NewFormatter(w io.Writer, options ...FormatterOption) Formatter {
 type formatter struct {
 	writer io.Writer
 
-	indent       string
-	indentSize   int
-	emitBuiltin  bool
-	emitComments bool
+	indent          string
+	indentSize      int
+	emitBuiltin     bool
+	emitComments    bool
+	omitDescription bool
 
 	padNext  bool
 	lineHead bool
@@ -112,7 +120,7 @@ func (f *formatter) WriteString(s string) *formatter {
 }
 
 func (f *formatter) WriteDescription(s string) *formatter {
-	if s == "" {
+	if s == "" || f.omitDescription {
 		return f
 	}
 

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -25,6 +25,7 @@ var optionSets = []struct {
 	{"default", nil},
 	{"spaceIndent", []formatter.FormatterOption{formatter.WithIndent(" ")}},
 	{"comments", []formatter.FormatterOption{formatter.WithComments()}},
+	{"no_description", []formatter.FormatterOption{formatter.WithoutDescription()}},
 }
 
 func TestFormatter_FormatSchema(t *testing.T) {

--- a/formatter/testdata/baseline/FormatQueryDocument/no_description/basic.graphql
+++ b/formatter/testdata/baseline/FormatQueryDocument/no_description/basic.graphql
@@ -1,0 +1,7 @@
+query FooBarQuery ($after: String!) {
+	fizzList(first: 100, after: $after) {
+		nodes {
+			id
+		}
+	}
+}

--- a/formatter/testdata/baseline/FormatQueryDocument/no_description/field.graphql
+++ b/formatter/testdata/baseline/FormatQueryDocument/no_description/field.graphql
@@ -1,0 +1,3 @@
+query {
+	bar: foo
+}

--- a/formatter/testdata/baseline/FormatQueryDocument/no_description/fragment.graphql
+++ b/formatter/testdata/baseline/FormatQueryDocument/no_description/fragment.graphql
@@ -1,0 +1,18 @@
+query FooBarQuery ($after: String!) {
+	fizzList(first: 100, after: $after) {
+		nodes {
+			id
+			... FooFragment
+			... on Foo {
+				id
+			}
+			... {
+				id
+			}
+			name
+		}
+	}
+}
+fragment FooFragment on Foo {
+	id
+}

--- a/formatter/testdata/baseline/FormatQueryDocument/no_description/variable.graphql
+++ b/formatter/testdata/baseline/FormatQueryDocument/no_description/variable.graphql
@@ -1,0 +1,8 @@
+query ($first: Int = 30, $after: String!) {
+	searchCats(first: $first, after: $after) {
+		nodes {
+			id
+			name
+		}
+	}
+}

--- a/formatter/testdata/baseline/FormatSchema/no_description/definition.graphql
+++ b/formatter/testdata/baseline/FormatSchema/no_description/definition.graphql
@@ -1,0 +1,24 @@
+scalar Cat0
+type Cat1 {
+	name: String
+}
+interface Cat2 {
+	name: String
+}
+union Cat3 = Cat3_0 | Cat3_1 | Cat3_2
+type Cat3_0 {
+	name: String
+}
+type Cat3_1 {
+	name: String
+}
+type Cat3_2 {
+	name: String
+}
+enum Cat4 {
+	NFC
+	MAINECOON
+}
+input Cat5 {
+	name: String
+}

--- a/formatter/testdata/baseline/FormatSchema/no_description/description.graphql
+++ b/formatter/testdata/baseline/FormatSchema/no_description/description.graphql
@@ -1,0 +1,4 @@
+type Cat {
+	name: String
+	speaks: String
+}

--- a/formatter/testdata/baseline/FormatSchema/no_description/directive.graphql
+++ b/formatter/testdata/baseline/FormatSchema/no_description/directive.graphql
@@ -1,0 +1,2 @@
+directive @bar repeatable on FIELD | OBJECT
+directive @foo on FIELD | OBJECT

--- a/formatter/testdata/baseline/FormatSchema/no_description/directive_locations.graphql
+++ b/formatter/testdata/baseline/FormatSchema/no_description/directive_locations.graphql
@@ -1,0 +1,13 @@
+directive @foo on OBJECT | UNION | ENUM
+enum ConnectionStatus @foo {
+	ONLINE
+	OFFLINE
+	ERROR
+}
+interface Named {
+	name: String!
+}
+type Person implements Named @foo {
+	name: String!
+}
+union PersonUnion @foo = Person

--- a/formatter/testdata/baseline/FormatSchema/no_description/extensions.graphql
+++ b/formatter/testdata/baseline/FormatSchema/no_description/extensions.graphql
@@ -1,0 +1,16 @@
+directive @extends on OBJECT
+directive @key(fields: String!) on OBJECT | INTERFACE
+directive @permission(permission: String!) on FIELD_DEFINITION
+type Dog {
+	name: String!
+	owner: Person! @permission(permission: "admin")
+}
+type Person @key(fields: "name") {
+	name: String!
+}
+type Query @extends {
+	dogs: [Dog!]!
+}
+type Subscription {
+	dogEvents: [Dog!]!
+}

--- a/formatter/testdata/baseline/FormatSchema/no_description/field_definition.graphql
+++ b/formatter/testdata/baseline/FormatSchema/no_description/field_definition.graphql
@@ -1,0 +1,3 @@
+input CatInput {
+	food: String = "fish & meat"
+}

--- a/formatter/testdata/baseline/FormatSchema/no_description/schema.graphql
+++ b/formatter/testdata/baseline/FormatSchema/no_description/schema.graphql
@@ -1,0 +1,34 @@
+schema {
+	query: TopQuery
+	mutation: TopMutation
+	subscription: TopSubscription
+}
+type TopMutation {
+	noop: Boolean
+	noop2(
+		arg: String
+	): Boolean
+	noop3(
+		arg: String
+	): Boolean
+}
+type TopQuery {
+	noop: Boolean
+	noop2(
+		arg: String
+	): Boolean
+	noop3(
+		arg: String
+	): Boolean
+}
+type TopSubscription {
+	noop: Boolean
+	noop2(
+		arg: String
+	): Boolean
+	noop3(
+		arg1: String
+
+		arg2: String
+	): Boolean
+}

--- a/formatter/testdata/baseline/FormatSchema/no_description/swapi.graphql
+++ b/formatter/testdata/baseline/FormatSchema/no_description/swapi.graphql
@@ -1,0 +1,87 @@
+interface Character {
+	id: ID!
+	name: String!
+	friends: [Character]
+	friendsConnection(first: Int, after: ID): FriendsConnection!
+	appearsIn: [Episode]!
+}
+input ColorInput {
+	red: Int!
+	green: Int!
+	blue: Int!
+}
+type Droid implements Character {
+	id: ID!
+	name: String!
+	friends: [Character]
+	friendsConnection(first: Int, after: ID): FriendsConnection!
+	appearsIn: [Episode]!
+	primaryFunction: String
+}
+enum Episode {
+	NEWHOPE
+	EMPIRE
+	JEDI
+}
+type FriendsConnection {
+	totalCount: Int
+	edges: [FriendsEdge]
+	friends: [Character]
+	pageInfo: PageInfo!
+}
+type FriendsEdge {
+	cursor: ID!
+	node: Character
+}
+type Human implements Character {
+	id: ID!
+	name: String!
+	homePlanet: String
+	height(unit: LengthUnit = METER): Float
+	mass: Float
+	friends: [Character]
+	friendsConnection(first: Int, after: ID): FriendsConnection!
+	appearsIn: [Episode]!
+	starships: [Starship]
+}
+enum LengthUnit {
+	METER
+	FOOT
+}
+type Mutation {
+	createReview(episode: Episode, review: ReviewInput!): Review
+}
+type PageInfo {
+	startCursor: ID
+	endCursor: ID
+	hasNextPage: Boolean!
+}
+type Query {
+	hero(episode: Episode): Character
+	reviews(episode: Episode!): [Review]
+	search(text: String): [SearchResult]
+	character(id: ID!): Character
+	droid(id: ID!): Droid
+	human(id: ID!): Human
+	starship(id: ID!): Starship
+}
+type Review {
+	episode: Episode
+	stars: Int!
+	commentary: String
+}
+input ReviewInput {
+	stars: Int!
+	commentary: String
+	favorite_color: ColorInput
+}
+union SearchResult = Human | Droid | Starship
+type Starship {
+	id: ID!
+	name: String!
+	length(unit: LengthUnit = METER): Float
+	coordinates: [[Float!]!]
+}
+type Subscription {
+	reviewAdded(episode: Episode): Review
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/no_description/definition.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/no_description/definition.graphql
@@ -1,0 +1,24 @@
+scalar Cat0
+type Cat1 {
+	name: String
+}
+interface Cat2 {
+	name: String
+}
+type Cat3_0 {
+	name: String
+}
+type Cat3_1 {
+	name: String
+}
+type Cat3_2 {
+	name: String
+}
+union Cat3 = Cat3_0 | Cat3_1 | Cat3_2
+enum Cat4 {
+	NFC
+	MAINECOON
+}
+input Cat5 {
+	name: String
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/no_description/description.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/no_description/description.graphql
@@ -1,0 +1,4 @@
+type Cat {
+	name: String
+	speaks: String
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/no_description/directive.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/no_description/directive.graphql
@@ -1,0 +1,2 @@
+directive @foo on FIELD | OBJECT
+directive @bar repeatable on FIELD | OBJECT

--- a/formatter/testdata/baseline/FormatSchemaDocument/no_description/directive_locations.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/no_description/directive_locations.graphql
@@ -1,0 +1,13 @@
+directive @foo on OBJECT | UNION | ENUM
+interface Named {
+	name: String!
+}
+type Person implements Named @foo {
+	name: String!
+}
+enum ConnectionStatus @foo {
+	ONLINE
+	OFFLINE
+	ERROR
+}
+union PersonUnion @foo = Person

--- a/formatter/testdata/baseline/FormatSchemaDocument/no_description/extensions.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/no_description/extensions.graphql
@@ -1,0 +1,24 @@
+schema {
+	query: Query
+}
+extend schema {
+	subscription: Subscription
+}
+directive @permission(permission: String!) on FIELD_DEFINITION
+directive @extends on OBJECT
+directive @key(fields: String!) on OBJECT | INTERFACE
+type Query @extends {
+	dogs: [Dog!]!
+}
+type Subscription {
+	dogEvents: [Dog!]!
+}
+type Dog {
+	name: String!
+}
+type Person @key(fields: "name") {
+	name: String!
+}
+extend type Dog {
+	owner: Person! @permission(permission: "admin")
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/no_description/field_definition.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/no_description/field_definition.graphql
@@ -1,0 +1,3 @@
+input CatInput {
+	food: String = "fish & meat"
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/no_description/schema.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/no_description/schema.graphql
@@ -1,0 +1,34 @@
+schema {
+	query: TopQuery
+	mutation: TopMutation
+	subscription: TopSubscription
+}
+type TopMutation {
+	noop: Boolean
+	noop2(
+		arg: String
+	): Boolean
+	noop3(
+		arg: String
+	): Boolean
+}
+type TopQuery {
+	noop: Boolean
+	noop2(
+		arg: String
+	): Boolean
+	noop3(
+		arg: String
+	): Boolean
+}
+type TopSubscription {
+	noop: Boolean
+	noop2(
+		arg: String
+	): Boolean
+	noop3(
+		arg1: String
+
+		arg2: String
+	): Boolean
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/no_description/swapi.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/no_description/swapi.graphql
@@ -1,0 +1,92 @@
+schema {
+	query: Query
+	mutation: Mutation
+	subscription: Subscription
+}
+type Query {
+	hero(episode: Episode): Character
+	reviews(episode: Episode!): [Review]
+	search(text: String): [SearchResult]
+	character(id: ID!): Character
+	droid(id: ID!): Droid
+	human(id: ID!): Human
+	starship(id: ID!): Starship
+}
+type Mutation {
+	createReview(episode: Episode, review: ReviewInput!): Review
+}
+type Subscription {
+	reviewAdded(episode: Episode): Review
+}
+enum Episode {
+	NEWHOPE
+	EMPIRE
+	JEDI
+}
+interface Character {
+	id: ID!
+	name: String!
+	friends: [Character]
+	friendsConnection(first: Int, after: ID): FriendsConnection!
+	appearsIn: [Episode]!
+}
+enum LengthUnit {
+	METER
+	FOOT
+}
+type Human implements Character {
+	id: ID!
+	name: String!
+	homePlanet: String
+	height(unit: LengthUnit = METER): Float
+	mass: Float
+	friends: [Character]
+	friendsConnection(first: Int, after: ID): FriendsConnection!
+	appearsIn: [Episode]!
+	starships: [Starship]
+}
+type Droid implements Character {
+	id: ID!
+	name: String!
+	friends: [Character]
+	friendsConnection(first: Int, after: ID): FriendsConnection!
+	appearsIn: [Episode]!
+	primaryFunction: String
+}
+type FriendsConnection {
+	totalCount: Int
+	edges: [FriendsEdge]
+	friends: [Character]
+	pageInfo: PageInfo!
+}
+type FriendsEdge {
+	cursor: ID!
+	node: Character
+}
+type PageInfo {
+	startCursor: ID
+	endCursor: ID
+	hasNextPage: Boolean!
+}
+type Review {
+	episode: Episode
+	stars: Int!
+	commentary: String
+}
+input ReviewInput {
+	stars: Int!
+	commentary: String
+	favorite_color: ColorInput
+}
+input ColorInput {
+	red: Int!
+	green: Int!
+	blue: Int!
+}
+type Starship {
+	id: ID!
+	name: String!
+	length(unit: LengthUnit = METER): Float
+	coordinates: [[Float!]!]
+}
+union SearchResult = Human | Droid | Starship


### PR DESCRIPTION
From the description.

The existing test framework generates really nice examples already.

I have:
 - [x] Added tests covering the bug / feature 
 - [x] Updated any relevant documentation
