### PR TITLE
feat(gqlerror): optimize Error method perfomance

### DIFF
--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -1,10 +1,10 @@
 package gqlerror
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -38,7 +38,7 @@ type Location struct {
 type List []*Error
 
 func (err *Error) Error() string {
-	var res bytes.Buffer
+	var res strings.Builder
 	if err == nil {
 		return ""
 	}
@@ -80,7 +80,7 @@ func (err *Error) AsError() error {
 }
 
 func (errs List) Error() string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	for _, err := range errs {
 		buf.WriteString(err.Error())
 		buf.WriteByte('\n')

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -164,5 +165,15 @@ func TestList_Is(t *testing.T) {
 				t.Errorf("List.Is() returned nil target, wants concrete error")
 			}
 		})
+	}
+}
+
+func BenchmarkError(b *testing.B) {
+	list := List([]*Error{error1, error2})
+	for i := 0; i < b.N; i++ {
+		_ = underlyingError.Error()
+		_ = error1.Error()
+		_ = error2.Error()
+		_ = list.Error()
 	}
 }


### PR DESCRIPTION
I found that for string concatenation, `strings.Builder` has better performance than `bytes.Buffer`. I have already tested the benchmark (`cd gqlerror && go test -bench=.`) for these approaches, and here are the results:
* When using `bytes.Buffer`
```shell
goos: darwin
goarch: arm64
pkg: github.com/vektah/gqlparser/v2/gqlerror
cpu: Apple M1 Max
BenchmarkError-10        4554457               262.9 ns/op
```
* When using `strings.Builder`
```shell
goos: darwin
goarch: arm64
pkg: github.com/vektah/gqlparser/v2/gqlerror
cpu: Apple M1 Max
BenchmarkError-10        5152414               218.0 ns/op
```

I have:
 - [x] Added tests covering the bug / feature 
 - [] Updated any relevant documentation
