### PR TITLE
Fix quote handling at end of block string descriptions

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -421,17 +421,29 @@ func (s *Lexer) readBlockString() (Token, error) {
 		r := s.Input[s.end]
 
 		// Closing triple quote (""")
-		if r == '"' && s.end+3 <= inputLen && s.Input[s.end:s.end+3] == `"""` {
-			t, err := s.makeValueToken(BlockString, blockStringValue(buf.String()))
+		if r == '"' {
+			// Count consecutive quotes
+			quoteCount := 1
+			i := s.end + 1
+			for i < inputLen && s.Input[i] == '"' {
+				quoteCount++
+				i++
+			}
 
-			// the token should not include the quotes in its value, but should cover them in its position
-			t.Pos.Start -= 3
-			t.Pos.End += 3
+			// If we have at least 3 quotes, use the last 3 as the closing quote
+			if quoteCount >= 3 {
+				// Add any extra quotes to the buffer (except the last 3)
+				for j := 0; j < quoteCount-3; j++ {
+					buf.WriteByte('"')
+				}
 
-			// skip the close quote
-			s.end += 3
-			s.endRunes += 3
-			return t, err
+				t, err := s.makeValueToken(BlockString, blockStringValue(buf.String()))
+				t.Pos.Start -= 3
+				t.Pos.End += 3
+				s.end += quoteCount
+				s.endRunes += quoteCount
+				return t, err
+			}
 		}
 
 		// SourceCharacter

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -160,7 +160,6 @@ func TestSchemaDescriptionWithQuotesAtEnd(t *testing.T) {
 		  field: String
 		}
 		`, BuiltIn: false})
-		require.Error(t, err, "Currently fails but should parse successfully")
-		require.Contains(t, err.Error(), "Unexpected <Invalid>", "Error should be about unexpected invalid token")
+		require.NoError(t, err, "Schema with quotes at end of description should parse successfully")
 	})
 }

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -136,3 +136,31 @@ func TestSchemaDescription(t *testing.T) {
 	want := "A simple GraphQL schema which is well described."
 	require.Equal(t, want, s.Description)
 }
+
+func TestSchemaDescriptionWithQuotesAtEnd(t *testing.T) {
+	// This test demonstrates a bug in the parser where quotes at the end of a
+	// description without a space cause parsing errors
+
+	t.Run("working case - quotes followed by space at end of description", func(t *testing.T) {
+		// This case works correctly - note the space after the quote and before the closing """
+		_, err := LoadSchema(Prelude, &ast.Source{Name: "test", Input: `
+		"""This is a "test" """
+		type Query {
+		  field: String
+		}
+		`, BuiltIn: false})
+		require.NoError(t, err, "Schema with quotes followed by space at end of description should parse successfully")
+	})
+
+	t.Run("bug - quotes at end of description", func(t *testing.T) {
+		// This case fails - note the quote directly before the closing """
+		_, err := LoadSchema(Prelude, &ast.Source{Name: "test", Input: `
+		"""This is a "test""""
+		type Query {
+		  field: String
+		}
+		`, BuiltIn: false})
+		require.Error(t, err, "Currently fails but should parse successfully")
+		require.Contains(t, err.Error(), "Unexpected <Invalid>", "Error should be about unexpected invalid token")
+	})
+}


### PR DESCRIPTION
  Fixes a bug in the GraphQL lexer where strings ending with quotes followed by closing delimiters (like `"""This is a "test""""`), would cause parsing errors.

  The lexer now properly handles consecutive quotes by counting them and treating the last three as closing delimiters, while including extra quotes in the content.

I have:
 - [x] Added tests covering the bug / feature 
 - [x] Updated any relevant documentation
