### PR TITLE
change: no longer include Position information when marshaling to JSON

### DIFF
--- a/ast/definition.go
+++ b/ast/definition.go
@@ -29,7 +29,7 @@ type Definition struct {
 	Types       []string      // union
 	EnumValues  EnumValueList // enum
 
-	Position *Position `dump:"-"`
+	Position *Position `dump:"-" json:"-"`
 	BuiltIn  bool      `dump:"-"`
 
 	BeforeDescriptionComment *CommentGroup
@@ -69,7 +69,7 @@ type FieldDefinition struct {
 	DefaultValue *Value                 // only for input objects
 	Type         *Type
 	Directives   DirectiveList
-	Position     *Position `dump:"-"`
+	Position     *Position `dump:"-" json:"-"`
 
 	BeforeDescriptionComment *CommentGroup
 	AfterDescriptionComment  *CommentGroup
@@ -81,7 +81,7 @@ type ArgumentDefinition struct {
 	DefaultValue *Value
 	Type         *Type
 	Directives   DirectiveList
-	Position     *Position `dump:"-"`
+	Position     *Position `dump:"-" json:"-"`
 
 	BeforeDescriptionComment *CommentGroup
 	AfterDescriptionComment  *CommentGroup
@@ -91,7 +91,7 @@ type EnumValueDefinition struct {
 	Description string
 	Name        string
 	Directives  DirectiveList
-	Position    *Position `dump:"-"`
+	Position    *Position `dump:"-" json:"-"`
 
 	BeforeDescriptionComment *CommentGroup
 	AfterDescriptionComment  *CommentGroup
@@ -103,7 +103,7 @@ type DirectiveDefinition struct {
 	Arguments    ArgumentDefinitionList
 	Locations    []DirectiveLocation
 	IsRepeatable bool
-	Position     *Position `dump:"-"`
+	Position     *Position `dump:"-" json:"-"`
 
 	BeforeDescriptionComment *CommentGroup
 	AfterDescriptionComment  *CommentGroup

--- a/ast/directive.go
+++ b/ast/directive.go
@@ -30,7 +30,7 @@ const (
 type Directive struct {
 	Name      string
 	Arguments ArgumentList
-	Position  *Position `dump:"-"`
+	Position  *Position `dump:"-" json:"-"`
 
 	// Requires validation
 	ParentDefinition *Definition

--- a/ast/document.go
+++ b/ast/document.go
@@ -3,7 +3,7 @@ package ast
 type QueryDocument struct {
 	Operations OperationList
 	Fragments  FragmentDefinitionList
-	Position   *Position `dump:"-"`
+	Position   *Position `dump:"-" json:"-"`
 	Comment    *CommentGroup
 }
 
@@ -13,7 +13,7 @@ type SchemaDocument struct {
 	Directives      DirectiveDefinitionList
 	Definitions     DefinitionList
 	Extensions      DefinitionList
-	Position        *Position `dump:"-"`
+	Position        *Position `dump:"-" json:"-"`
 	Comment         *CommentGroup
 }
 
@@ -74,7 +74,7 @@ type SchemaDefinition struct {
 	Description    string
 	Directives     DirectiveList
 	OperationTypes OperationTypeDefinitionList
-	Position       *Position `dump:"-"`
+	Position       *Position `dump:"-" json:"-"`
 
 	BeforeDescriptionComment *CommentGroup
 	AfterDescriptionComment  *CommentGroup
@@ -84,6 +84,6 @@ type SchemaDefinition struct {
 type OperationTypeDefinition struct {
 	Operation Operation
 	Type      string
-	Position  *Position `dump:"-"`
+	Position  *Position `dump:"-" json:"-"`
 	Comment   *CommentGroup
 }

--- a/ast/fragment.go
+++ b/ast/fragment.go
@@ -8,7 +8,7 @@ type FragmentSpread struct {
 	ObjectDefinition *Definition
 	Definition       *FragmentDefinition
 
-	Position *Position `dump:"-"`
+	Position *Position `dump:"-" json:"-"`
 	Comment  *CommentGroup
 }
 
@@ -20,7 +20,7 @@ type InlineFragment struct {
 	// Require validation
 	ObjectDefinition *Definition
 
-	Position *Position `dump:"-"`
+	Position *Position `dump:"-" json:"-"`
 	Comment  *CommentGroup
 }
 
@@ -36,6 +36,6 @@ type FragmentDefinition struct {
 	// Require validation
 	Definition *Definition
 
-	Position *Position `dump:"-"`
+	Position *Position `dump:"-" json:"-"`
 	Comment  *CommentGroup
 }

--- a/ast/operation.go
+++ b/ast/operation.go
@@ -14,7 +14,7 @@ type OperationDefinition struct {
 	VariableDefinitions VariableDefinitionList
 	Directives          DirectiveList
 	SelectionSet        SelectionSet
-	Position            *Position `dump:"-"`
+	Position            *Position `dump:"-" json:"-"`
 	Comment             *CommentGroup
 }
 
@@ -23,7 +23,7 @@ type VariableDefinition struct {
 	Type         *Type
 	DefaultValue *Value
 	Directives   DirectiveList
-	Position     *Position `dump:"-"`
+	Position     *Position `dump:"-" json:"-"`
 	Comment      *CommentGroup
 
 	// Requires validation

--- a/ast/selection.go
+++ b/ast/selection.go
@@ -21,7 +21,7 @@ type Field struct {
 	Arguments    ArgumentList
 	Directives   DirectiveList
 	SelectionSet SelectionSet
-	Position     *Position `dump:"-"`
+	Position     *Position `dump:"-" json:"-"`
 	Comment      *CommentGroup
 
 	// Require validation
@@ -32,7 +32,7 @@ type Field struct {
 type Argument struct {
 	Name     string
 	Value    *Value
-	Position *Position `dump:"-"`
+	Position *Position `dump:"-" json:"-"`
 	Comment  *CommentGroup
 }
 

--- a/ast/type.go
+++ b/ast/type.go
@@ -20,7 +20,7 @@ type Type struct {
 	NamedType string
 	Elem      *Type
 	NonNull   bool
-	Position  *Position `dump:"-"`
+	Position  *Position `dump:"-" json:"-"`
 }
 
 func (t *Type) Name() string {

--- a/ast/value.go
+++ b/ast/value.go
@@ -25,7 +25,7 @@ type Value struct {
 	Raw      string
 	Children ChildValueList
 	Kind     ValueKind
-	Position *Position `dump:"-"`
+	Position *Position `dump:"-" json:"-"`
 	Comment  *CommentGroup
 
 	// Require validation
@@ -37,7 +37,7 @@ type Value struct {
 type ChildValue struct {
 	Name     string
 	Value    *Value
-	Position *Position `dump:"-"`
+	Position *Position `dump:"-" json:"-"`
 	Comment  *CommentGroup
 }
 


### PR DESCRIPTION
I have a need to marshal the AST to JSON to input into Open Policy Agent, but when I do this for non-trivial schemas the Position information takes a massive amount of memory.
This PR aligns the JSON Marshal rules with the dump rules, which also do not marshal Position.

I have attached a [reproducer](https://github.com/user-attachments/files/19701507/reproducer.go.txt) to demonstrate the issue.

```sh
# On master this allocates 30+GB of memory and never finishes.

$ go build -o reproducer reproducer.go && time ./reproducer
Now passing 1262568 bytes to ParseSchema() to demonstrate the benefit of the json marshaling change
Alloc = 4160 MiB	TotalAlloc = 5630 MiB	Sys = 5578 MiB	NumGC = 18
Alloc = 8312 MiB	TotalAlloc = 11174 MiB	Sys = 11120 MiB	NumGC = 19
Alloc = 19392 MiB	TotalAlloc = 22254 MiB	Sys = 22203 MiB	NumGC = 19
Alloc = 16616 MiB	TotalAlloc = 22254 MiB	Sys = 22203 MiB	NumGC = 20
Alloc = 16616 MiB	TotalAlloc = 22254 MiB	Sys = 22203 MiB	NumGC = 20
Alloc = 16616 MiB	TotalAlloc = 22254 MiB	Sys = 22203 MiB	NumGC = 20
Alloc = 33223 MiB	TotalAlloc = 44405 MiB	Sys = 44371 MiB	NumGC = 21
Alloc = 33223 MiB	TotalAlloc = 44405 MiB	Sys = 44371 MiB	NumGC = 21
Alloc = 33223 MiB	TotalAlloc = 44405 MiB	Sys = 44371 MiB	NumGC = 21
Alloc = 33223 MiB	TotalAlloc = 44405 MiB	Sys = 44371 MiB	NumGC = 21
Alloc = 33223 MiB	TotalAlloc = 44405 MiB	Sys = 44371 MiB	NumGC = 21

# With the position JSON annotation change this finishes in well under a second.

$ go build -o reproducer reproducer.go && time ./reproducer
Now passing 1262568 bytes to ParseSchema() to demonstrate the benefit of the json marshaling change
Got 3705551 bytes of JSON

real	0m0.380s
user	0m0.075s
sys	0m0.020s
```

All tests pass, so I do not think this change breaks any supported use case.

```sh
$ go test  ./...
?   	github.com/vektah/gqlparser/v2	[no test files]
ok  	github.com/vektah/gqlparser/v2/ast	0.197s
ok  	github.com/vektah/gqlparser/v2/formatter	0.706s
ok  	github.com/vektah/gqlparser/v2/gqlerror	0.849s
ok  	github.com/vektah/gqlparser/v2/lexer	0.527s
?   	github.com/vektah/gqlparser/v2/main	[no test files]
ok  	github.com/vektah/gqlparser/v2/parser	0.366s
?   	github.com/vektah/gqlparser/v2/parser/testrunner	[no test files]
ok  	github.com/vektah/gqlparser/v2/validator	1.195s
ok  	github.com/vektah/gqlparser/v2/validator/rules	0.994s
```