### PR TITLE
Fix formatting schema and schema extensions directives in FormatSchema() and FormatSchemaDocument()

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -176,7 +176,11 @@ func (f *formatter) FormatSchema(schema *ast.Schema) {
 		if !inSchema {
 			inSchema = true
 
-			f.WriteWord("schema").WriteString("{").WriteNewline()
+			f.WriteWord("schema")
+
+			f.FormatDirectiveList(schema.SchemaDirectives)
+
+			f.WriteString("{").WriteNewline()
 			f.IncrementIndent()
 		}
 	}

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -283,22 +283,43 @@ func (f *formatter) FormatSchemaDefinitionList(lists ast.SchemaDefinitionList, e
 	if extension {
 		f.WriteWord("extend")
 	}
-	f.WriteWord("schema").WriteString("{").WriteNewline()
-	f.IncrementIndent()
+	f.WriteWord("schema")
 
+	f.IncrementIndent()
 	for _, def := range lists {
-		f.FormatSchemaDefinition(def)
+		f.FormatDirectiveList(def.Directives)
+	}
+	f.DecrementIndent()
+
+	// Don't output empty schema definition block for extensions
+	if !extension || !f.IsSchemaDefinitionsEmpty(lists) {
+		f.WriteString("{").WriteNewline()
+		f.IncrementIndent()
+
+		for _, def := range lists {
+			f.FormatSchemaDefinition(def)
+		}
+
+		f.FormatCommentGroup(endOfDefinitionComment)
+
+		f.DecrementIndent()
+		f.WriteString("}")
 	}
 
-	f.FormatCommentGroup(endOfDefinitionComment)
+	f.WriteNewline()
+}
 
-	f.DecrementIndent()
-	f.WriteString("}").WriteNewline()
+// Return true if schema definitions is empty (besides directives), false otherwise
+func (f *formatter) IsSchemaDefinitionsEmpty(lists ast.SchemaDefinitionList) bool {
+	for _, def := range lists {
+		if len(def.OperationTypes) > 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func (f *formatter) FormatSchemaDefinition(def *ast.SchemaDefinition) {
-	f.FormatDirectiveList(def.Directives)
-
 	f.FormatOperationTypeDefinitionList(def.OperationTypes)
 }
 

--- a/formatter/testdata/baseline/FormatSchema/comments/schema-directives.graphql
+++ b/formatter/testdata/baseline/FormatSchema/comments/schema-directives.graphql
@@ -1,0 +1,11 @@
+schema @schemaDirective(arg: ["val1","val2"]) @schemaExtensionDirective1(arg: ["val1","val2"]) @schemaExtensionDirective2(arg: ["val1","val2"]) @schemaExtensionDirective3(arg: ["val1","val2"]) {
+	query: Dummy
+	subscription: Dummy
+}
+directive @schemaDirective(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective1(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective2(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective3(arg: [String!]!) on SCHEMA
+type Dummy {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchema/compacted/schema-directives.graphql
+++ b/formatter/testdata/baseline/FormatSchema/compacted/schema-directives.graphql
@@ -1,0 +1,11 @@
+schema @schemaDirective(arg: ["val1","val2"]) @schemaExtensionDirective1(arg: ["val1","val2"]) @schemaExtensionDirective2(arg: ["val1","val2"]) @schemaExtensionDirective3(arg: ["val1","val2"]) {
+	query: Dummy
+	subscription: Dummy
+}
+directive @schemaDirective(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective1(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective2(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective3(arg: [String!]!) on SCHEMA
+type Dummy {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchema/default/schema-directives.graphql
+++ b/formatter/testdata/baseline/FormatSchema/default/schema-directives.graphql
@@ -1,0 +1,11 @@
+schema @schemaDirective(arg: ["val1","val2"]) @schemaExtensionDirective1(arg: ["val1","val2"]) @schemaExtensionDirective2(arg: ["val1","val2"]) @schemaExtensionDirective3(arg: ["val1","val2"]) {
+	query: Dummy
+	subscription: Dummy
+}
+directive @schemaDirective(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective1(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective2(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective3(arg: [String!]!) on SCHEMA
+type Dummy {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchema/no_description/schema-directives.graphql
+++ b/formatter/testdata/baseline/FormatSchema/no_description/schema-directives.graphql
@@ -1,0 +1,11 @@
+schema @schemaDirective(arg: ["val1","val2"]) @schemaExtensionDirective1(arg: ["val1","val2"]) @schemaExtensionDirective2(arg: ["val1","val2"]) @schemaExtensionDirective3(arg: ["val1","val2"]) {
+	query: Dummy
+	subscription: Dummy
+}
+directive @schemaDirective(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective1(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective2(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective3(arg: [String!]!) on SCHEMA
+type Dummy {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchema/spaceIndent/schema-directives.graphql
+++ b/formatter/testdata/baseline/FormatSchema/spaceIndent/schema-directives.graphql
@@ -1,0 +1,11 @@
+schema @schemaDirective(arg: ["val1","val2"]) @schemaExtensionDirective1(arg: ["val1","val2"]) @schemaExtensionDirective2(arg: ["val1","val2"]) @schemaExtensionDirective3(arg: ["val1","val2"]) {
+ query: Dummy
+ subscription: Dummy
+}
+directive @schemaDirective(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective1(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective2(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective3(arg: [String!]!) on SCHEMA
+type Dummy {
+ id: ID
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/comments/schema-directives.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/comments/schema-directives.graphql
@@ -1,0 +1,13 @@
+schema @schemaDirective(arg: ["val1","val2"]) {
+	query: Dummy
+}
+extend schema @schemaExtensionDirective1(arg: ["val1","val2"]) @schemaExtensionDirective2(arg: ["val1","val2"]) @schemaExtensionDirective3(arg: ["val1","val2"]) {
+	subscription: Dummy
+}
+directive @schemaDirective(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective1(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective2(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective3(arg: [String!]!) on SCHEMA
+type Dummy {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/compacted/schema-directives.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/compacted/schema-directives.graphql
@@ -1,0 +1,13 @@
+schema @schemaDirective(arg: ["val1","val2"]) {
+	query: Dummy
+}
+extend schema @schemaExtensionDirective1(arg: ["val1","val2"]) @schemaExtensionDirective2(arg: ["val1","val2"]) @schemaExtensionDirective3(arg: ["val1","val2"]) {
+	subscription: Dummy
+}
+directive @schemaDirective(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective1(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective2(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective3(arg: [String!]!) on SCHEMA
+type Dummy {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/default/schema-directives.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/default/schema-directives.graphql
@@ -1,0 +1,13 @@
+schema @schemaDirective(arg: ["val1","val2"]) {
+	query: Dummy
+}
+extend schema @schemaExtensionDirective1(arg: ["val1","val2"]) @schemaExtensionDirective2(arg: ["val1","val2"]) @schemaExtensionDirective3(arg: ["val1","val2"]) {
+	subscription: Dummy
+}
+directive @schemaDirective(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective1(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective2(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective3(arg: [String!]!) on SCHEMA
+type Dummy {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/no_description/schema-directives.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/no_description/schema-directives.graphql
@@ -1,0 +1,13 @@
+schema @schemaDirective(arg: ["val1","val2"]) {
+	query: Dummy
+}
+extend schema @schemaExtensionDirective1(arg: ["val1","val2"]) @schemaExtensionDirective2(arg: ["val1","val2"]) @schemaExtensionDirective3(arg: ["val1","val2"]) {
+	subscription: Dummy
+}
+directive @schemaDirective(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective1(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective2(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective3(arg: [String!]!) on SCHEMA
+type Dummy {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/spaceIndent/schema-directives.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/spaceIndent/schema-directives.graphql
@@ -1,0 +1,13 @@
+schema @schemaDirective(arg: ["val1","val2"]) {
+ query: Dummy
+}
+extend schema @schemaExtensionDirective1(arg: ["val1","val2"]) @schemaExtensionDirective2(arg: ["val1","val2"]) @schemaExtensionDirective3(arg: ["val1","val2"]) {
+ subscription: Dummy
+}
+directive @schemaDirective(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective1(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective2(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective3(arg: [String!]!) on SCHEMA
+type Dummy {
+ id: ID
+}

--- a/formatter/testdata/source/schema/schema-directives.graphql
+++ b/formatter/testdata/source/schema/schema-directives.graphql
@@ -1,0 +1,14 @@
+schema @schemaDirective(arg: ["val1","val2"]) {
+	query: Dummy
+}
+extend schema @schemaExtensionDirective1(arg: ["val1","val2"]) {
+	subscription: Dummy
+}
+extend schema @schemaExtensionDirective2(arg: ["val1","val2"]) @schemaExtensionDirective3(arg: ["val1","val2"])
+directive @schemaDirective(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective1(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective2(arg: [String!]!) on SCHEMA
+directive @schemaExtensionDirective3(arg: [String!]!) on SCHEMA
+type Dummy {
+	id: ID
+}


### PR DESCRIPTION
This merge request hopefully fixes two bugs in formatter, described below. Also added tests for these cases.

## Input
GraphQL schema document, used as input:
```graphql
schema @schemaDirective {
	query: Dummy
}
extend schema @schemaExtensionDirective1
extend schema @schemaExtensionDirective2 @schemaExtensionDirective3
extend schema {
	subscription: Dummy
}
directive @schemaDirective on SCHEMA
directive @schemaExtensionDirective1 on SCHEMA
directive @schemaExtensionDirective2 on SCHEMA
directive @schemaExtensionDirective3 on SCHEMA
type Dummy {
	id: ID
}
```
## Bug in formatter.FormatSchema()
The following code
```go
package main

import (
    "bytes"
    "os"

    "github.com/vektah/gqlparser/v2"
    "github.com/vektah/gqlparser/v2/ast"
    "github.com/vektah/gqlparser/v2/formatter"
)

func main() {
    if len(os.Args) < 2 {
        panic("need graphql file as argument")
    }

    input, _ := os.ReadFile(os.Args[1])
    src := &ast.Source{
        Name: os.Args[1],
        Input: string(input),
    }

    schema, err := gqlparser.LoadSchema(src)
    if err != nil {
        panic(err)
    }

    var buf bytes.Buffer
    f := formatter.NewFormatter(&buf)
    f.FormatSchema(schema)

    buf.WriteTo(os.Stdout)
}
```

produces this output
```graphql
schema {
	query: Dummy
	subscription: Dummy
}
[... insignificant part omitted]
```

omitting all schema and schema extension directives.

## Bug in formatter.FormatSchemaDocument()
Following code
```go
package main

import (
    "bytes"
    "os"

    "github.com/vektah/gqlparser/v2/ast"
    "github.com/vektah/gqlparser/v2/formatter"
    "github.com/vektah/gqlparser/v2/parser"
)

func main() {
    if len(os.Args) < 2 {
        panic("need graphql file as argument")
    }

    input, _ := os.ReadFile(os.Args[1])
    src := &ast.Source{
        Name: os.Args[1],
        Input: string(input),
    }

    sd, err := parser.ParseSchemas(src)
    if err != nil {
        panic(err)
    }

    var buf bytes.Buffer
    f := formatter.NewFormatter(&buf)
    f.FormatSchemaDocument(sd)

    buf.WriteTo(os.Stdout)
}
```

produces this output:
```graphql
schema {
	@schemaDirective query: Dummy
}
extend schema {
	@schemaExtensionDirective1 @schemaExtensionDirective2 @schemaExtensionDirective3 subscription: Dummy
}
[... insignificant part omitted]
```
Here schema directives appear inside schema definition block, which contradicts the [spec](https://spec.graphql.org/draft/#sec-Schema). Directives should appear before definition block, correct output would be:
```graphql
schema @schemaDirective {
	query: Dummy
}
extend schema @schemaExtensionDirective1 @schemaExtensionDirective2 @schemaExtensionDirective3 {
	subscription: Dummy
}
[... insignificant part omitted]
```


I have:
 - [x] Added tests covering the bug / feature 
 - [x] Updated any relevant documentation
