### PR TITLE
Fix loosing schema directives in FormatSchema() when schema definition only contains default operation types and gets optimized out

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -202,6 +202,15 @@ func (f *formatter) FormatSchema(schema *ast.Schema) {
 	if inSchema {
 		f.DecrementIndent()
 		f.WriteString("}").WriteNewline()
+	} else if len(schema.SchemaDirectives) > 0 {
+		// Schema definition is omitted from output, but it has
+		// directives. Output them as the schema extension to not loose
+		// them
+		f.WriteWord("extend").WriteWord("schema")
+
+		f.FormatDirectiveList(schema.SchemaDirectives)
+
+		f.WriteNewline()
 	}
 
 	directiveNames := make([]string, 0, len(schema.Directives))

--- a/formatter/testdata/baseline/FormatSchema/comments/schema-directive-with-empty-schema.graphql
+++ b/formatter/testdata/baseline/FormatSchema/comments/schema-directive-with-empty-schema.graphql
@@ -1,0 +1,5 @@
+extend schema @schemaDirective
+directive @schemaDirective on SCHEMA
+type Query {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchema/compacted/schema-directive-with-empty-schema.graphql
+++ b/formatter/testdata/baseline/FormatSchema/compacted/schema-directive-with-empty-schema.graphql
@@ -1,0 +1,5 @@
+extend schema @schemaDirective
+directive @schemaDirective on SCHEMA
+type Query {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchema/default/schema-directive-with-empty-schema.graphql
+++ b/formatter/testdata/baseline/FormatSchema/default/schema-directive-with-empty-schema.graphql
@@ -1,0 +1,5 @@
+extend schema @schemaDirective
+directive @schemaDirective on SCHEMA
+type Query {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchema/no_description/schema-directive-with-empty-schema.graphql
+++ b/formatter/testdata/baseline/FormatSchema/no_description/schema-directive-with-empty-schema.graphql
@@ -1,0 +1,5 @@
+extend schema @schemaDirective
+directive @schemaDirective on SCHEMA
+type Query {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchema/spaceIndent/schema-directive-with-empty-schema.graphql
+++ b/formatter/testdata/baseline/FormatSchema/spaceIndent/schema-directive-with-empty-schema.graphql
@@ -1,0 +1,5 @@
+extend schema @schemaDirective
+directive @schemaDirective on SCHEMA
+type Query {
+ id: ID
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/comments/schema-directive-with-empty-schema.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/comments/schema-directive-with-empty-schema.graphql
@@ -1,0 +1,11 @@
+schema @schemaDirective {
+	# Since this operation has default type name "Query", it will be
+	# dropped by FormatSchema(), and the schema definition will became
+	# empty. So @schemaDirective should be moved to schema extension to not
+	# be lost.
+	query: Query
+}
+directive @schemaDirective on SCHEMA
+type Query {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/compacted/schema-directive-with-empty-schema.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/compacted/schema-directive-with-empty-schema.graphql
@@ -1,0 +1,7 @@
+schema @schemaDirective {
+	query: Query
+}
+directive @schemaDirective on SCHEMA
+type Query {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/default/schema-directive-with-empty-schema.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/default/schema-directive-with-empty-schema.graphql
@@ -1,0 +1,7 @@
+schema @schemaDirective {
+	query: Query
+}
+directive @schemaDirective on SCHEMA
+type Query {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/no_description/schema-directive-with-empty-schema.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/no_description/schema-directive-with-empty-schema.graphql
@@ -1,0 +1,7 @@
+schema @schemaDirective {
+	query: Query
+}
+directive @schemaDirective on SCHEMA
+type Query {
+	id: ID
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/spaceIndent/schema-directive-with-empty-schema.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/spaceIndent/schema-directive-with-empty-schema.graphql
@@ -1,0 +1,7 @@
+schema @schemaDirective {
+ query: Query
+}
+directive @schemaDirective on SCHEMA
+type Query {
+ id: ID
+}

--- a/formatter/testdata/source/schema/schema-directive-with-empty-schema.graphql
+++ b/formatter/testdata/source/schema/schema-directive-with-empty-schema.graphql
@@ -1,0 +1,11 @@
+schema @schemaDirective {
+	# Since this operation has default type name "Query", it will be
+	# dropped by FormatSchema(), and the schema definition will became
+	# empty. So @schemaDirective should be moved to schema extension to not
+	# be lost.
+	query: Query
+}
+directive @schemaDirective on SCHEMA
+type Query {
+	id: ID
+}


### PR DESCRIPTION
Found and, hopefully, fixed another bug, related to #365.

When schema definition only contains default operation types, it gets optimized out by
FormatSchema(), and directives attached to a schema are lost.

For example, for the following input:
```graphql
schema @schemaDirective {
    query: Query
}
directive @schemaDirective on SCHEMA
type Query {
    id: ID
}
```
FormatSchema() produces:
```graphql
directive @schemaDirective on SCHEMA
type Query {
	id: ID
}
```

Commonly used method to workaroud this is to move schema directives to a schema
extension, for the output to look like this:

```graphql
extend schema @schemaDirective
directive @schemaDirective on SCHEMA
type Query {
    id: ID
}
```

Code to reproduce the bug:
```go
package main

import (
    "bytes"
    "os"

    "github.com/vektah/gqlparser/v2"
    "github.com/vektah/gqlparser/v2/ast"
    "github.com/vektah/gqlparser/v2/formatter"
)

func main() {
    src := &ast.Source{
        Name: "",
        Input: `
            schema @schemaDirective {
                query: Query
            }
            directive @schemaDirective on SCHEMA
            type Query {
                id: ID
            }
        `,
    }

    schema, err := gqlparser.LoadSchema(src)
    if err != nil {
        panic(err)
    }

    var buf bytes.Buffer
    f := formatter.NewFormatter(&buf)
    f.FormatSchema(schema)

    buf.WriteTo(os.Stdout)
}
```

I have:
 - [x] Added tests covering the bug / feature 
 - [x] Updated any relevant documentation
