### PR TITLE
Add column information to errors

### DIFF
--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -51,6 +51,8 @@ func (err *Error) Error() string {
 	if len(err.Locations) > 0 {
 		res.WriteByte(':')
 		res.WriteString(strconv.Itoa(err.Locations[0].Line))
+		res.WriteByte(':')
+		res.WriteString(strconv.Itoa(err.Locations[0].Column))
 	}
 
 	res.WriteString(": ")

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -35,14 +35,14 @@ func TestErrorFormatting(t *testing.T) {
 	t.Run("without filename", func(t *testing.T) {
 		err := ErrorLocf("", 66, 2, "kabloom")
 
-		require.Equal(t, `input:66: kabloom`, err.Error())
+		require.Equal(t, `input:66:2: kabloom`, err.Error())
 		require.Nil(t, err.Extensions["file"])
 	})
 
 	t.Run("with filename", func(t *testing.T) {
 		err := ErrorLocf("schema.graphql", 66, 2, "kabloom")
 
-		require.Equal(t, `schema.graphql:66: kabloom`, err.Error())
+		require.Equal(t, `schema.graphql:66:2: kabloom`, err.Error())
 		require.Equal(t, "schema.graphql", err.Extensions["file"])
 	})
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -67,7 +67,7 @@ func TestParserUtils(t *testing.T) {
 					p.error(p.peek(), "boom")
 				}
 			})
-			require.EqualError(t, p.err, "input.graphql:1: boom")
+			require.EqualError(t, p.err, "input.graphql:1:6: boom")
 			require.Equal(t, []string{"a", "b"}, arr)
 		})
 	})
@@ -94,7 +94,7 @@ func TestParserUtils(t *testing.T) {
 			p.some(lexer.BracketL, lexer.BracketR, func() {
 				arr = append(arr, p.next().Value)
 			})
-			require.EqualError(t, p.err, "input.graphql:1: expected at least one definition, found ]")
+			require.EqualError(t, p.err, "input.graphql:1:2: expected at least one definition, found ]")
 			require.Equal(t, []string(nil), arr)
 			require.NotEqual(t, lexer.EOF, p.peek().Kind)
 		})
@@ -119,7 +119,7 @@ func TestParserUtils(t *testing.T) {
 					p.error(p.peek(), "boom")
 				}
 			})
-			require.EqualError(t, p.err, "input.graphql:1: boom")
+			require.EqualError(t, p.err, "input.graphql:1:6: boom")
 			require.Equal(t, []string{"a", "b"}, arr)
 		})
 	})
@@ -131,7 +131,7 @@ func TestParserUtils(t *testing.T) {
 		p.error(p.peek(), "test error")
 		p.error(p.peek(), "secondary error")
 
-		require.EqualError(t, p.err, "input.graphql:1: test error")
+		require.EqualError(t, p.err, "input.graphql:1:5: test error")
 
 		require.Equal(t, "foo", p.peek().Value)
 		require.Equal(t, "foo", p.next().Value)
@@ -141,27 +141,27 @@ func TestParserUtils(t *testing.T) {
 	t.Run("unexpected error", func(t *testing.T) {
 		p := newParser("1 3")
 		p.unexpectedError()
-		require.EqualError(t, p.err, "input.graphql:1: Unexpected Int \"1\"")
+		require.EqualError(t, p.err, "input.graphql:1:1: Unexpected Int \"1\"")
 	})
 
 	t.Run("unexpected error", func(t *testing.T) {
 		p := newParser("1 3")
 		p.unexpectedToken(p.next())
-		require.EqualError(t, p.err, "input.graphql:1: Unexpected Int \"1\"")
+		require.EqualError(t, p.err, "input.graphql:1:1: Unexpected Int \"1\"")
 	})
 
 	t.Run("expect error", func(t *testing.T) {
 		p := newParser("foo bar")
 		p.expect(lexer.Float)
 
-		require.EqualError(t, p.err, "input.graphql:1: Expected Float, found Name")
+		require.EqualError(t, p.err, "input.graphql:1:1: Expected Float, found Name")
 	})
 
 	t.Run("expectKeyword error", func(t *testing.T) {
 		p := newParser("foo bar")
 		p.expectKeyword("baz")
 
-		require.EqualError(t, p.err, "input.graphql:1: Expected \"baz\", found Name \"foo\"")
+		require.EqualError(t, p.err, "input.graphql:1:1: Expected \"baz\", found Name \"foo\"")
 	})
 }
 

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -74,7 +74,7 @@ query SomeOperation {
 	require.NoError(t, err)
 	r1 := validator.Validate(s, q1)
 	require.Len(t, r1, 1)
-	const errorString = `SomeOperation:4: Field "myAction" argument "myEnum" of type "Locale!" is required, but it was not provided.`
+	const errorString = `SomeOperation:4:2: Field "myAction" argument "myEnum" of type "Locale!" is required, but it was not provided.`
 	require.EqualError(t, r1[0], errorString)
 
 	// Some other call that should not affect validator behavior


### PR DESCRIPTION
This PR adds column information to errors to alleviate one reason for OPA to maintain an internal fork of gqlparser.
I'd wait to see how the OPA folks respond before merging this change.

- gqlgen PR https://github.com/99designs/gqlgen/pull/3685 for information purposes
- addresses https://github.com/vektah/gqlparser/issues/367
- Open Policy Agent discussion https://github.com/open-policy-agent/opa/issues/7520

I have:
 - [x] Added tests covering the bug / feature 
 - [x] Updated any relevant documentation - I don't think there is any relevant documentation on this.
