### PR TITLE
Change parser limit error to be gqlerror

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/vektah/gqlparser/v2/ast"
@@ -106,7 +105,7 @@ func (p *parser) next() lexer.Token {
 	// Increment the token count before reading the next token
 	p.tokenCount++
 	if p.maxTokenLimit != 0 && p.tokenCount > p.maxTokenLimit {
-		p.err = fmt.Errorf("exceeded token limit of %d", p.maxTokenLimit)
+		p.err = gqlerror.Errorf("exceeded token limit of %d", p.maxTokenLimit)
 		return p.prev
 	}
 	if p.peeked {


### PR DESCRIPTION
As reported by @hansod1 in github.com/99designs/gqlgen#3693 
When in #291 we added the token limit, we should have used gqlerror to be more consistent 
For reference, [here is the change in gqlparser that added the new error](https://github.com/vektah/gqlparser/pull/291/files#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R109).

As a result, the error is not as easy to detect as being from the parser because [this part ](https://github.com/99designs/gqlgen/blob/master/graphql/executor/executor.go#L209) of the gqlgen codebase does not correctly interpret the token limit error as a parsing error because it is not returned from the parser as a `*gqlerror.Error`, and rather is an `errors.errorString` created with `fmt.Errorf`:

```
	doc, err := parser.ParseQueryWithTokenLimit(&ast.Source{Input: query}, e.parserTokenLimit)
	if err != nil {
		gqlErr, ok := err.(*gqlerror.Error)
		if ok {
			errcode.Set(gqlErr, errcode.ParseFailed)
			return nil, gqlerror.List{gqlErr}
		}
	}
```

We should add a lint rule that bans `fmt.Errorf` and adds nolint comments for our remaining uses in our panics but I only got 3 hours of sleep so not doing that now.

Signed-off-by: Steve Coffman <steve@khanacademy.org>
