### PR TITLE
Fix formatter when schema uses a mix of custom and default root opera…

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -184,17 +184,22 @@ func (f *formatter) FormatSchema(schema *ast.Schema) {
 			f.IncrementIndent()
 		}
 	}
-	if schema.Query != nil && schema.Query.Name != "Query" {
+
+	needSchema := (schema.Query != nil && schema.Query.Name != "Query") ||
+		(schema.Mutation != nil && schema.Mutation.Name != "Mutation") ||
+		(schema.Subscription != nil && schema.Subscription.Name != "Subscription")
+
+	if needSchema && schema.Query != nil {
 		startSchema()
 		f.WriteWord("query").NoPadding().WriteString(":").NeedPadding()
 		f.WriteWord(schema.Query.Name).WriteNewline()
 	}
-	if schema.Mutation != nil && schema.Mutation.Name != "Mutation" {
+	if needSchema && schema.Mutation != nil {
 		startSchema()
 		f.WriteWord("mutation").NoPadding().WriteString(":").NeedPadding()
 		f.WriteWord(schema.Mutation.Name).WriteNewline()
 	}
-	if schema.Subscription != nil && schema.Subscription.Name != "Subscription" {
+	if needSchema && schema.Subscription != nil {
 		startSchema()
 		f.WriteWord("subscription").NoPadding().WriteString(":").NeedPadding()
 		f.WriteWord(schema.Subscription.Name).WriteNewline()

--- a/formatter/testdata/baseline/FormatSchema/comments/root-operation-types.graphql
+++ b/formatter/testdata/baseline/FormatSchema/comments/root-operation-types.graphql
@@ -1,0 +1,54 @@
+schema {
+	query: TopQuery
+	mutation: Mutation
+}
+type Mutation {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
+}
+type Subscription {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg1: String
+
+		"""
+		noop3 foo bar
+		"""
+		arg2: String
+	): Boolean
+}
+type TopQuery {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
+}

--- a/formatter/testdata/baseline/FormatSchema/compacted/root-operation-types.graphql
+++ b/formatter/testdata/baseline/FormatSchema/compacted/root-operation-types.graphql
@@ -1,0 +1,54 @@
+schema {
+	query: TopQuery
+	mutation: Mutation
+}
+type Mutation {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
+}
+type Subscription {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg1: String
+
+		"""
+		noop3 foo bar
+		"""
+		arg2: String
+	): Boolean
+}
+type TopQuery {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
+}

--- a/formatter/testdata/baseline/FormatSchema/default/root-operation-types.graphql
+++ b/formatter/testdata/baseline/FormatSchema/default/root-operation-types.graphql
@@ -1,0 +1,54 @@
+schema {
+	query: TopQuery
+	mutation: Mutation
+}
+type Mutation {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
+}
+type Subscription {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg1: String
+
+		"""
+		noop3 foo bar
+		"""
+		arg2: String
+	): Boolean
+}
+type TopQuery {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
+}

--- a/formatter/testdata/baseline/FormatSchema/no_description/root-operation-types.graphql
+++ b/formatter/testdata/baseline/FormatSchema/no_description/root-operation-types.graphql
@@ -1,0 +1,19 @@
+schema {
+	query: TopQuery
+	mutation: Mutation
+}
+type Mutation {
+	noop: Boolean
+	noop2(arg: String): Boolean
+	noop3(arg: String): Boolean
+}
+type Subscription {
+	noop: Boolean
+	noop2(arg: String): Boolean
+	noop3(arg1: String arg2: String): Boolean
+}
+type TopQuery {
+	noop: Boolean
+	noop2(arg: String): Boolean
+	noop3(arg: String): Boolean
+}

--- a/formatter/testdata/baseline/FormatSchema/spaceIndent/root-operation-types.graphql
+++ b/formatter/testdata/baseline/FormatSchema/spaceIndent/root-operation-types.graphql
@@ -1,0 +1,54 @@
+schema {
+ query: TopQuery
+ mutation: Mutation
+}
+type Mutation {
+ noop: Boolean
+ noop2(
+  """
+  noop2 foo bar
+  """
+  arg: String
+ ): Boolean
+ noop3(
+  """
+  noop3 foo bar
+  """
+  arg: String
+ ): Boolean
+}
+type Subscription {
+ noop: Boolean
+ noop2(
+  """
+  noop2 foo bar
+  """
+  arg: String
+ ): Boolean
+ noop3(
+  """
+  noop3 foo bar
+  """
+  arg1: String
+
+  """
+  noop3 foo bar
+  """
+  arg2: String
+ ): Boolean
+}
+type TopQuery {
+ noop: Boolean
+ noop2(
+  """
+  noop2 foo bar
+  """
+  arg: String
+ ): Boolean
+ noop3(
+  """
+  noop3 foo bar
+  """
+  arg: String
+ ): Boolean
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/comments/root-operation-types.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/comments/root-operation-types.graphql
@@ -1,0 +1,62 @@
+# before schema description comment
+"""
+schema description
+"""
+# after schema description comment
+schema {
+	# before query comment
+	query: TopQuery
+	# before mutation comment
+	mutation: Mutation
+	# end of schema comment
+}
+type Mutation {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
+}
+type TopQuery {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
+}
+type Subscription {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg1: String
+
+		"""
+		noop3 foo bar
+		"""
+		arg2: String
+	): Boolean
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/compacted/root-operation-types.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/compacted/root-operation-types.graphql
@@ -1,0 +1,57 @@
+"""
+schema description
+"""
+schema {
+	query: TopQuery
+	mutation: Mutation
+}
+type Mutation {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
+}
+type TopQuery {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
+}
+type Subscription {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg1: String
+
+		"""
+		noop3 foo bar
+		"""
+		arg2: String
+	): Boolean
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/default/root-operation-types.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/default/root-operation-types.graphql
@@ -1,0 +1,57 @@
+"""
+schema description
+"""
+schema {
+	query: TopQuery
+	mutation: Mutation
+}
+type Mutation {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
+}
+type TopQuery {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg: String
+	): Boolean
+}
+type Subscription {
+	noop: Boolean
+	noop2(
+		"""
+		noop2 foo bar
+		"""
+		arg: String
+	): Boolean
+	noop3(
+		"""
+		noop3 foo bar
+		"""
+		arg1: String
+
+		"""
+		noop3 foo bar
+		"""
+		arg2: String
+	): Boolean
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/no_description/root-operation-types.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/no_description/root-operation-types.graphql
@@ -1,0 +1,19 @@
+schema {
+	query: TopQuery
+	mutation: Mutation
+}
+type Mutation {
+	noop: Boolean
+	noop2(arg: String): Boolean
+	noop3(arg: String): Boolean
+}
+type TopQuery {
+	noop: Boolean
+	noop2(arg: String): Boolean
+	noop3(arg: String): Boolean
+}
+type Subscription {
+	noop: Boolean
+	noop2(arg: String): Boolean
+	noop3(arg1: String arg2: String): Boolean
+}

--- a/formatter/testdata/baseline/FormatSchemaDocument/spaceIndent/root-operation-types.graphql
+++ b/formatter/testdata/baseline/FormatSchemaDocument/spaceIndent/root-operation-types.graphql
@@ -1,0 +1,57 @@
+"""
+schema description
+"""
+schema {
+ query: TopQuery
+ mutation: Mutation
+}
+type Mutation {
+ noop: Boolean
+ noop2(
+  """
+  noop2 foo bar
+  """
+  arg: String
+ ): Boolean
+ noop3(
+  """
+  noop3 foo bar
+  """
+  arg: String
+ ): Boolean
+}
+type TopQuery {
+ noop: Boolean
+ noop2(
+  """
+  noop2 foo bar
+  """
+  arg: String
+ ): Boolean
+ noop3(
+  """
+  noop3 foo bar
+  """
+  arg: String
+ ): Boolean
+}
+type Subscription {
+ noop: Boolean
+ noop2(
+  """
+  noop2 foo bar
+  """
+  arg: String
+ ): Boolean
+ noop3(
+  """
+  noop3 foo bar
+  """
+  arg1: String
+
+  """
+  noop3 foo bar
+  """
+  arg2: String
+ ): Boolean
+}

--- a/formatter/testdata/source/schema/root-operation-types.graphql
+++ b/formatter/testdata/source/schema/root-operation-types.graphql
@@ -1,0 +1,54 @@
+# before schema description comment
+"schema description"
+# after schema description comment
+schema {
+  # before query comment
+	query: TopQuery
+  # before mutation comment
+	mutation: Mutation
+  # end of schema comment
+}
+
+type Mutation {
+    noop: Boolean
+    noop2("""
+      noop2 foo bar
+      """
+      arg: String
+    ): Boolean
+    noop3("noop3 foo bar"
+      arg: String
+    ): Boolean
+}
+
+type TopQuery {
+      noop: Boolean
+
+      noop2("""
+        noop2 foo bar
+        """
+        arg: String
+      ): Boolean
+
+      noop3(
+        "noop3 foo bar"
+        arg: String
+      ): Boolean
+}
+
+type Subscription {
+      noop: Boolean
+
+      noop2(
+        """noop2 foo bar"""
+        arg: String
+      ): Boolean
+
+      noop3(
+        "noop3 foo bar"
+        arg1: String
+
+        "noop3 foo bar"
+        arg2: String
+      ): Boolean
+}


### PR DESCRIPTION
…tion type names

From the GraphQL spec:
> While any type can be the root operation type for a GraphQL operation, the type system definition language can omit the schema definition when the query, mutation, and subscription root types are named "Query", "Mutation", and "Subscription" respectively.
> Likewise, when representing a GraphQL schema using the type system definition language, a schema definition should be omitted if it only uses the default root operation type names.

If a schema uses a mix of custom and default root operation type names, the formatter should emit a complete schema definition for all root operations defined.

Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature 
 - [ ] Updated any relevant documentation
