### PR TITLE
fix: ErrorPosf() handle nil Position input

### DIFF
--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -164,6 +164,15 @@ func ErrorPathf(path ast.Path, message string, args ...interface{}) *Error {
 }
 
 func ErrorPosf(pos *ast.Position, message string, args ...interface{}) *Error {
+	if pos == nil {
+		return ErrorLocf(
+			"",
+			-1,
+			-1,
+			message,
+			args...,
+		)
+	}
 	return ErrorLocf(
 		pos.Src.Name,
 		pos.Line,

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -53,6 +53,18 @@ func TestErrorFormatting(t *testing.T) {
 	})
 }
 
+func TestErrorPosition(t *testing.T) {
+	t.Run("with nil position", func(t *testing.T) {
+		err := ErrorLocf("", -1, -1, "kabloom")
+		errNilPosition := ErrorPosf(nil, "%s", "kabloom")
+
+		require.Equal(t, `input:-1:-1: kabloom`, err.Error())
+		require.Equal(t, errNilPosition.Error(), err.Error())
+		require.Nil(t, err.Extensions["file"])
+		require.Nil(t, errNilPosition.Extensions["file"])
+	})
+}
+
 func TestList_As(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Open Policy Agent prunes Position information from its AST tree prior to calling validator.ValidateSchemaDocument(), which causes a runtime error and panic when a bad schema is encountered because `ErrorPosf()` does not check for nil input.

This PR adds a test case and returns some default values if a `nil` pos is passed to `ErrorPosf()`.

The default values I've chosen may not be the best as some people do not expect row/column information to be negative. See #254, for example.  I'm not tied to these values - I just don't want a crash in this case.

I didn't see any related documentation that needed an  update handling this case.

I have:
 - [x] Added tests covering the bug / feature
 - [x] Ran `go test ./...` to ensure no other tests fail as a result of this change

This resolves #375