### PR TITLE
BREAKING: Fix `AddRule` and `ReplaceRule` methods behavior and add documentation

### DIFF
--- a/validator/rules/rules.go
+++ b/validator/rules/rules.go
@@ -58,7 +58,10 @@ func (r *Rules) AddRule(name string, ruleFunc core.RuleFunc) {
 	if r.rules == nil {
 		r.rules = make(map[string]core.RuleFunc)
 	}
-	r.rules[name] = ruleFunc
+
+	if _, exists := r.rules[name]; !exists {
+		r.rules[name] = ruleFunc
+	}
 }
 
 func (r *Rules) GetInner() map[string]core.RuleFunc {
@@ -78,5 +81,7 @@ func (r *Rules) ReplaceRule(name string, ruleFunc core.RuleFunc) {
 	if r.rules == nil {
 		r.rules = make(map[string]core.RuleFunc)
 	}
-	r.rules[name] = ruleFunc
+	if _, exists := r.rules[name]; exists {
+		r.rules[name] = ruleFunc
+	}
 }

--- a/validator/rules/rules.go
+++ b/validator/rules/rules.go
@@ -2,10 +2,12 @@ package rules
 
 import "github.com/vektah/gqlparser/v2/validator/core"
 
+// Rules manages GraphQL validation rules.
 type Rules struct {
 	rules map[string]core.RuleFunc
 }
 
+// NewRules creates a Rules instance with the specified rules.
 func NewRules(rs ...core.Rule) *Rules {
 	r := &Rules{
 		rules: make(map[string]core.RuleFunc),
@@ -18,6 +20,7 @@ func NewRules(rs ...core.Rule) *Rules {
 	return r
 }
 
+// NewDefaultRules creates a Rules instance containing the default GraphQL validation rule set.
 func NewDefaultRules() *Rules {
 	rules := []core.Rule{
 		FieldsOnCorrectTypeRule,
@@ -54,6 +57,8 @@ func NewDefaultRules() *Rules {
 	return r
 }
 
+// AddRule adds a rule with the specified name and rule function to the rule set.
+// If a rule with the same name already exists, it will not be added.
 func (r *Rules) AddRule(name string, ruleFunc core.RuleFunc) {
 	if r.rules == nil {
 		r.rules = make(map[string]core.RuleFunc)
@@ -64,6 +69,8 @@ func (r *Rules) AddRule(name string, ruleFunc core.RuleFunc) {
 	}
 }
 
+// GetInner returns the internal rule map.
+// If the map is not initialized, it returns an empty map.
 func (r *Rules) GetInner() map[string]core.RuleFunc {
 	if r.rules == nil {
 		return make(map[string]core.RuleFunc)
@@ -71,12 +78,16 @@ func (r *Rules) GetInner() map[string]core.RuleFunc {
 	return r.rules
 }
 
+// RemoveRule removes a rule with the specified name from the rule set.
+// If no rule with the specified name exists, it does nothing.
 func (r *Rules) RemoveRule(name string) {
 	if r.rules != nil {
 		delete(r.rules, name)
 	}
 }
 
+// ReplaceRule replaces a rule with the specified name with a new rule function.
+// If no rule with the specified name exists, it does nothing.
 func (r *Rules) ReplaceRule(name string, ruleFunc core.RuleFunc) {
 	if r.rules == nil {
 		r.rules = make(map[string]core.RuleFunc)


### PR DESCRIPTION
## Description

This PR modifies the `Rules` struct in the validator package by fixing a minor behavioral bug in the rule management methods.
I partially implemented AddRule and ReplaceRule methods incorrectly. I apologize for the oversight in my previous implementation.

## Changes
- Add some docs
- **`AddRule`**: Now If a rule with the same name already exists, it will not be added.
- **`ReplaceRule`**: Now If no rule with the specified name exists, it does nothing.

## Relates to
https://github.com/vektah/gqlparser/pull/379
https://github.com/vektah/gqlparser/pull/380

---

 - [ ] Added tests covering the bug / feature 
 - [ ] Updated any relevant documentation
