### PR TITLE
Ensure Validation Rule order is deterministic

### DIFF
--- a/validator/core/core.go
+++ b/validator/core/core.go
@@ -13,4 +13,12 @@ type Rule struct {
 	RuleFunc RuleFunc
 }
 
+// NameSorter sorts Rules by name.
+// usage: sort.Sort(core.NameSorter(specifiedRules))
+type NameSorter []Rule
+
+func (a NameSorter) Len() int           { return len(a) }
+func (a NameSorter) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a NameSorter) Less(i, j int) bool { return a[i].Name < a[j].Name }
+
 type ErrorOption func(err *gqlerror.Error)


### PR DESCRIPTION
Follow-up to #379 and #380 and #381

Recently, there was the beginning of an effort by @tomoikey to discourage the use of global variables in gqlparser.

Those changes,  [per my comment here](https://github.com/vektah/gqlparser/pull/381#issuecomment-3015990153), we have inadvertently made the order in which validation rules are applied non-deterministic.

This can cause problems in downstream projects in their continuous integration tests, as they might not get perfectly identical results due to ordering differences. This PR attempts to make the ordering of validation rules deterministic.

Note: I do NOT think this is now the **best** order of validation rule precedence, NOR do I think the original order was that either. They were and still are sorted arbitrarily only to have a deterministic precedence.

Also, if you were to add custom rule(s) using BOTH the deprecated and non-deprecated methods, and then to compare the validation order precedence, they would not be perfectly identical, because this is not expected to be of any consequence.

Signed-off-by: Steve Coffman <steve@khanacademy.org>
