### PR TITLE
fix(validator): allow nullable variables for nonnull args with default

### DIFF
--- a/ast/value.go
+++ b/ast/value.go
@@ -29,9 +29,10 @@ type Value struct {
 	Comment  *CommentGroup
 
 	// Require validation
-	Definition         *Definition
-	VariableDefinition *VariableDefinition
-	ExpectedType       *Type
+	Definition             *Definition
+	VariableDefinition     *VariableDefinition
+	ExpectedType           *Type
+	ExpectedTypeHasDefault bool
 }
 
 type ChildValue struct {

--- a/validator/core/walk.go
+++ b/validator/core/walk.go
@@ -182,6 +182,7 @@ func (w *Walker) walkValue(value *ast.Value) {
 				fieldDef := value.Definition.Fields.ForName(child.Name)
 				if fieldDef != nil {
 					child.Value.ExpectedType = fieldDef.Type
+					child.Value.ExpectedTypeHasDefault = fieldDef.DefaultValue != nil && fieldDef.DefaultValue.Kind != ast.NullValue
 					child.Value.Definition = w.Schema.Types[fieldDef.Type.Name()]
 				}
 			}
@@ -208,6 +209,7 @@ func (w *Walker) walkValue(value *ast.Value) {
 func (w *Walker) walkArgument(argDef *ast.ArgumentDefinition, arg *ast.Argument) {
 	if argDef != nil {
 		arg.Value.ExpectedType = argDef.Type
+		arg.Value.ExpectedTypeHasDefault = argDef.DefaultValue != nil && argDef.DefaultValue.Kind != ast.NullValue
 		arg.Value.Definition = w.Schema.Types[argDef.Type.Name()]
 	}
 

--- a/validator/rules/variables_in_allowed_position.go
+++ b/validator/rules/variables_in_allowed_position.go
@@ -25,6 +25,11 @@ var VariablesInAllowedPositionRule = Rule{
 				}
 			}
 
+			// If the expected type has a default, the given variable can be null
+			if value.ExpectedTypeHasDefault {
+				tmp.NonNull = false
+			}
+
 			if !value.VariableDefinition.Type.IsCompatible(&tmp) {
 				addError(
 					Message(


### PR DESCRIPTION
The validation was failing for arguments that are defined as required, but have a default value, preventing a non-required argument to override their value, while it should work as expected.

Given the tests are imported from JS, I'm not sure how to add a new one there. Here's an example schema and query to reproduce this:
```
type Query {
  user(username: String! = "foo"): User
}

type User {
  username: String!
}
```

```
query Foo($username: String) {
  user(username: $username) {
    username
  }
}
```

I have:
 - [ ] Added tests covering the bug / feature 
 - [ ] Updated any relevant documentation
