### PR TITLE
Add a nil check in ArgumentMap

### DIFF
--- a/ast/directive.go
+++ b/ast/directive.go
@@ -39,5 +39,8 @@ type Directive struct {
 }
 
 func (d *Directive) ArgumentMap(vars map[string]interface{}) map[string]interface{} {
+	if d.Definition == nil {
+		return nil
+	}
 	return arg2map(d.Definition.Arguments, d.Arguments, vars)
 }

--- a/ast/selection.go
+++ b/ast/selection.go
@@ -37,5 +37,8 @@ type Argument struct {
 }
 
 func (f *Field) ArgumentMap(vars map[string]interface{}) map[string]interface{} {
+	if f.Definition == nil {
+		return nil
+	}
 	return arg2map(f.Definition.Arguments, f.Arguments, vars)
 }


### PR DESCRIPTION
Describe your PR and link to any relevant issues. 

When a `Definition` of `Directive` or `Field` isn't present, `ArgumentMap` would panic as opposed to return nil.

We ran into this panic bug a few times in our project. Thoughts on making it more defensive?

I have:
 - [ ] Added tests covering the bug / feature 
 - [ ] Updated any relevant documentation
