### PR TITLE
refactor: format lines in scalar_leafs.go

### DIFF
--- a/validator/rules/scalar_leafs.go
+++ b/validator/rules/scalar_leafs.go
@@ -19,7 +19,11 @@ func ruleFuncScalarLeafs(observers *Events, addError AddErrFunc, disableSuggesti
 
 		if fieldType.IsLeafType() && len(field.SelectionSet) > 0 {
 			addError(
-				Message(`Field "%s" must not have a selection since type "%s" has no subfields.`, field.Name, fieldType.Name),
+				Message(
+					`Field "%s" must not have a selection since type "%s" has no subfields.`,
+					field.Name,
+					fieldType.Name,
+				),
 				At(field.Position),
 			)
 		}
@@ -27,7 +31,11 @@ func ruleFuncScalarLeafs(observers *Events, addError AddErrFunc, disableSuggesti
 		if !fieldType.IsLeafType() && len(field.SelectionSet) == 0 {
 			if disableSuggestion {
 				addError(
-					Message(`Field "%s" of type "%s" must have a selection of subfields.`, field.Name, field.Definition.Type.String()),
+					Message(
+						`Field "%s" of type "%s" must have a selection of subfields.`,
+						field.Name,
+						field.Definition.Type.String(),
+					),
 					At(field.Position),
 				)
 			} else {


### PR DESCRIPTION
Somehow, after https://github.com/vektah/gqlparser/pull/413 is merged in, the pipeline failed. This can be fixed by `golangci-linter run . --fix` to fix it.

Describe your PR and link to any relevant issues. 

I have:
 - [x] Added tests covering the bug / feature 
 - [x] Updated any relevant documentation
