### PR TITLE
fix fragment definition directive variable handling

### DIFF
--- a/validator/core/walk.go
+++ b/validator/core/walk.go
@@ -295,6 +295,7 @@ func (w *Walker) walkSelection(parentDef *ast.Definition, it ast.Selection) {
 		if def != nil && !w.validatedFragmentSpreads[def.Name] {
 			// prevent infinite recursion
 			w.validatedFragmentSpreads[def.Name] = true
+			w.walkDirectives(nextParentDef, def.Directives, ast.LocationFragmentDefinition)
 			w.walkSelectionSet(nextParentDef, def.SelectionSet)
 		}
 

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -223,6 +223,31 @@ func TestNoUnusedVariablesWithRules(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, validator.ValidateWithRules(s, q, nil))
 	})
+
+	t.Run("variable used in fragment definition directive", func(t *testing.T) {
+		s := gqlparser.MustLoadSchema(
+			&ast.Source{Name: "graph/schema.graphqls", Input: `
+	directive @testDirective(x: Int) on FRAGMENT_DEFINITION
+
+	type Query {
+		bar: String!
+	}
+	`, BuiltIn: false},
+		)
+
+		q, err := parser.ParseQuery(&ast.Source{Name: "fragmentDefinitionDirective", Input: `
+			query Foo($x: Int) {
+				...Bar
+			}
+
+			fragment Bar on Query @testDirective(x: $x) {
+				bar
+			}
+		`})
+		require.NoError(t, err)
+
+		require.Nil(t, validator.ValidateWithRules(s, q, nil))
+	})
 }
 
 func TestCustomRuleSet(t *testing.T) {


### PR DESCRIPTION
Hi there! I'm the maintainer of [graphql-conformance](https://jbellenger.github.io/graphql-conformance/#), which verifies spec conformance across the graphql ecosystem.

I noticed that [gqlgen](https://jbellenger.github.io/graphql-conformance/#/impl/gqlgen/failures/656ced21%2F1da08990%2F3a7eeb80) had some test failures that appear to originate in gqlparser.

The issue is that gqlparser does not walk directives on fragment definitions. When those directives are the only use of a variable, then those variables will be marked as unused and will incorrectly produce a validation error.

For example, in this configuration:
```graphql
# schema
directive @testDirective(x: Int) on FRAGMENT_DEFINITION
type Query { placeholder: Int! }

# query
query ($x:Int) { ... F }
fragment F on Query @testDirective(x:$x) { __typename }
```

gqlparser produces this error:
```
query:2:8: Variable "$x" is never used.
```

This PR fixes this by walking directives of fragment definitions.

Thank you for considering this PR! I'm not familiar with this code-base or its conventions, so please feel free to point out any issue no matter how small.