### PR TITLE
lexer: render invalid-character codepoint as hex, not decimal

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -193,7 +193,7 @@ func (s *Lexer) ReadToken() (Token, error) {
 	s.endRunes--
 
 	if r < 0x0020 && r != 0x0009 && r != 0x000a && r != 0x000d {
-		return s.makeError(`Cannot contain the invalid character "\u%04d"`, r)
+		return s.makeError(`Cannot contain the invalid character "\u%04x"`, r)
 	}
 
 	if r == '\'' {
@@ -365,7 +365,7 @@ func (s *Lexer) readString() (Token, error) {
 			break
 		}
 		if r < 0x0020 && r != '\t' {
-			return s.makeError(`Invalid character within String: "\u%04d".`, r)
+			return s.makeError(`Invalid character within String: "\u%04x".`, r)
 		}
 		switch r {
 		default:
@@ -505,7 +505,7 @@ func (s *Lexer) readBlockString() (Token, error) {
 
 		// SourceCharacter
 		if r < 0x0020 && r != '\t' && r != '\n' && r != '\r' {
-			return s.makeError(`Invalid character within String: "\u%04d".`, r)
+			return s.makeError(`Invalid character within String: "\u%04x".`, r)
 		}
 
 		switch {

--- a/lexer/lexer_test.yml
+++ b/lexer/lexer_test.yml
@@ -231,6 +231,12 @@ lex reports useful string errors:
       message: 'Invalid character within String: "\u0000".'
       locations: [{ line: 1, column: 19 }]
 
+  - name: control character codepoint reported in hex
+    input: "\"contains \u000e sub char\""
+    error:
+      message: 'Invalid character within String: "\u000e".'
+      locations: [{ line: 1, column: 11 }]
+
   - name: unterminated newline
     input: "\"multi\nline\""
     error:


### PR DESCRIPTION
Three "Invalid character" / "Cannot contain the invalid character" messages in lexer.go format the offending rune with `%04d`, which prints the byte in decimal. The surrounding `\u` prefix implies a Unicode codepoint, so any rune past U+0009 comes out wrong:

```
input:  "contains [0x0E] sub char"
got:    Invalid character within String: "".
want:   Invalid character within String: "".
```

Same drift for 0x0A shown as 0010, 0x1F as 0031, etc.

The existing yml tests only exercised 0x07 and 0x00, where decimal and hex format identically, so the bug stayed invisible. Added a case for 0x0E.

`go test ./...` is clean with the fix.
