### PR TITLE
fix: reject duplicate enum values and repeated non-repeatable directives

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -12,27 +12,9 @@ Two facts apply throughout this analysis.
 
 ## Unintentional gaps
 
-### `UniqueEnumValueNames` — missing entirely
-
-gqlparser's `Enum` case in `validateDefinition` (`schema.go:285`) checks only that the value list is non-empty and that no value is named `true`, `false`, or `null`. There is no duplicate check. Enum values from extensions are appended unconditionally at line 58 (`def.EnumValues = append(def.EnumValues, ext.EnumValues...)`), and nothing checks for duplicates afterward.
-
-This schema loads silently:
-
-```graphql
-enum Direction { NORTH SOUTH }
-extend enum Direction { NORTH }
-```
-
-graphql-js rejects with:
-> `Enum value "Direction.NORTH" already exists in the schema. It cannot also be defined in this type extension.`
-
-`schema_test.yml` has no case covering enum value uniqueness, confirming this is untested.
-
----
-
 ### `UniqueArgumentDefinitionNames` — missing entirely
 
-`validateArgs` (`schema.go:337`) checks that argument names don't begin with `__`, that referenced types exist, and that argument directives are valid. It never checks for duplicate argument names within the same list. Both field arguments and directive arguments are unprotected:
+`validateArgs` (`schema.go:432`) checks that argument names don't begin with `__`, that referenced types exist, and that argument directives are valid. It never checks for duplicate argument names within the same list. Both field arguments and directive arguments are unprotected:
 
 ```graphql
 type Query {
@@ -57,7 +39,7 @@ graphql-js rejects any attempt to specify the same operation type more than once
 schema { query: A  query: B }
 ```
 
-The loop at `schema.go:110` processes both entries and assigns `schema.Query` twice. Last writer wins, no error. `schema_test.yml`'s "multiple schema entry points" test only covers two separate `schema {}` blocks, not two operations within one block.
+The loop at `schema.go:124` processes both entries and assigns `schema.Query` twice. Last writer wins, no error. `schema_test.yml`'s "multiple schema entry points" test only covers two separate `schema {}` blocks, not two operations within one block.
 
 **Case B — two `extend schema` blocks both specifying the same operation:**
 
@@ -67,7 +49,7 @@ extend schema { mutation: Mut }
 extend schema { mutation: OtherMut }
 ```
 
-The loop at `schema.go:130` overwrites `schema.Mutation` on the second extension. No error.
+The loop at `schema.go:155` overwrites `schema.Mutation` on the second extension. No error.
 
 **Case C — `extend schema` re-specifying an operation from the base `schema {}` block:**
 
@@ -85,7 +67,7 @@ extend schema { query: Other }
 
 ### `PossibleTypeExtensions` — allows extensions of undefined types
 
-When an extension references a type that doesn't exist, gqlparser creates a synthetic `Definition` for it (`schema.go:40–47`) and continues. graphql-js rejects with:
+When an extension references a type that doesn't exist, gqlparser creates a synthetic `Definition` for it (`schema.go:41–48`) and continues. graphql-js rejects with:
 > `Cannot extend type "X" because it is not defined.`
 
 This is **intentional**: `schema_test.yml` has an explicit test case "can extend non existant types" asserting no error. The practical use case is federation-style schemas where types are extended without a local base definition.
@@ -96,22 +78,26 @@ The consequence worth noting: the resulting ghost type does pass through `valida
 
 ### `UniqueDirectiveNames` — builtin redeclaration silently accepted
 
-For non-builtin directives, gqlparser correctly returns an error (`schema.go:98`), tested by `schema_test.yml`'s "cannot redeclare directives" case. For the six builtins — `include`, `skip`, `deprecated`, `specifiedBy`, `defer`, `oneOf` — a redeclaration is silently accepted with the first definition kept. `schema_test.yml` has an explicit "can redeclare builtin directives" test asserting this.
+For non-builtin directives, gqlparser correctly returns an error (`schema.go:107`), tested by `schema_test.yml`'s "cannot redeclare directives" case. For the six builtins — `include`, `skip`, `deprecated`, `specifiedBy`, `defer`, `oneOf` — a redeclaration is silently accepted with the first definition kept. `schema_test.yml` has an explicit "can redeclare builtin directives" test asserting this.
 
 graphql-js rejects any directive redefinition, including builtins:
 > `Directive "@skip" already exists in the schema. It cannot be redefined.`
 
-The rationale is documented at `schema.go:93`: servers may ship directive definitions from an older or divergent spec version, and validating definition equivalence is considered more work than it's worth. The practical consequence is that a schema with a conflicting `@deprecated` or `@skip` definition loads without error.
+The rationale is documented at `schema.go:95`: servers may ship directive definitions from an older or divergent spec version, and validating definition equivalence is considered more work than it's worth. The practical consequence is that a schema with a conflicting `@deprecated` or `@skip` definition loads without error.
 
 ---
 
 ## Confirmed covered
 
-**`UniqueTypeNames`** — the first-pass map insertion at `schema.go:29–34` catches any type defined more than once in the document, returning `"Cannot redeclare type X."` Tested by `schema_test.yml`.
+**`UniqueTypeNames`** — the first-pass map insertion at `schema.go:30–34` catches any type defined more than once in the document, returning `"Cannot redeclare type X."` Tested by `schema_test.yml`.
 
-**`UniqueFieldDefinitionNames`** — field merging (`schema.go:56`) is followed by an O(n²) pair-scan at `schema.go:311–317`, catching duplicates within a definition, across definition + extension, and across multiple extensions. Tested by three cases in `schema_test.yml`.
+**`UniqueFieldDefinitionNames`** — field merging (`schema.go:63`) is followed by an O(n²) pair-scan at `schema.go:386–397`, catching duplicates within a definition, across definition + extension, and across multiple extensions. Tested by three cases in `schema_test.yml`.
 
-**`LoneSchemaDefinition`** — `len(sd.Schema) > 1` is checked at `schema.go:104`. The graphql-js check for "schema already defined in prior context" is an isolated-validation architectural difference, not a gap.
+**`UniqueEnumValueNames`** — enum value merging (`schema.go:65`) is followed by an O(n²) pair-scan at `schema.go:399–410`, mirroring the field check, catching duplicates within a definition and across extensions, returning `"Enum value X.Y can only be defined once."` Tested by two cases in `schema_test.yml` (same definition and across an extension).
+
+**`UniqueDirectivesPerLocation` (SDL)** — `validateDirectives` (`schema.go:468`) tracks seen directive names per call and rejects a repeated non-repeatable directive with `"The directive X can only be used once at this location."` It is gated by a `singleLocation` flag (`schema.go:479`) so it applies only to single authored locations — fields, enum values, arguments, and the `schema` / `extend schema` directive lists. A type's own directives are exempt: they are merged across the base definition and every extension (`schema.go:65`-style append for `def.Directives`), which the spec treats as distinct locations, so the merged list validated at `schema.go:422` passes `singleLocation: false`. Consequence worth noting: a non-repeatable directive repeated within a single type definition (e.g. `type T @x @x` with no extension) is **not** caught, because provenance is lost once the base and extension directive lists are merged — directive definitions aren't even registered until `schema.go:112`, after the merge. graphql-js catches this by validating pre-merge AST nodes. Tested by four cases in `schema_test.yml` (non-repeatable directive repeated on a field and on an enum value; positive cases for a repeatable directive, the same directive on distinct field locations, and a directive on a type plus its extension).
+
+**`LoneSchemaDefinition`** — `len(sd.Schema) > 1` is checked at `schema.go:115`. The graphql-js check for "schema already defined in prior context" is an isolated-validation architectural difference, not a gap.
 
 ---
 
@@ -119,11 +105,12 @@ The rationale is documented at `schema.go:93`: servers may ship directive defini
 
 | Rule | Status | Nature |
 |---|---|---|
-| `UniqueEnumValueNames` | Missing | Unintentional gap — no test, no check |
 | `UniqueArgumentDefinitionNames` | Missing | Unintentional gap — no test, no check |
 | `UniqueOperationTypes` | Missing (3 cases) | Unintentional gap — silent overwrite |
 | `PossibleTypeExtensions` | Intentional divergence | Allows ghost types; federation use case |
 | `UniqueDirectiveNames` (builtins) | Intentional divergence | Explicit test documents the choice |
 | `UniqueTypeNames` | Covered | — |
 | `UniqueFieldDefinitionNames` | Covered | — |
+| `UniqueEnumValueNames` | Covered | Pair-scan mirroring the field check; tested |
+| `UniqueDirectivesPerLocation` (SDL) | Covered (with caveat) | Per single authored location; merged type-level list exempt |
 | `LoneSchemaDefinitionRule` | Covered / arch. difference | Within-doc check present |

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -145,6 +145,7 @@ func ValidateSchemaDocument(sd *SchemaDocument) (*Schema, error) {
 			sd.Schema[0].Directives,
 			LocationSchema,
 			nil,
+			true,
 		); err != nil {
 			return nil, err
 		}
@@ -171,7 +172,13 @@ func ValidateSchemaDocument(sd *SchemaDocument) (*Schema, error) {
 				schema.Subscription = def
 			}
 		}
-		if err := validateDirectives(&schema, ext.Directives, LocationSchema, nil); err != nil {
+		if err := validateDirectives(
+			&schema,
+			ext.Directives,
+			LocationSchema,
+			nil,
+			true,
+		); err != nil {
 			return nil, err
 		}
 		schema.SchemaDirectives = append(schema.SchemaDirectives, ext.Directives...)
@@ -277,7 +284,13 @@ func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 		if def.Kind == InputObject {
 			wantDirLocation = LocationInputFieldDefinition
 		}
-		if err := validateDirectives(schema, field.Directives, wantDirLocation, nil); err != nil {
+		if err := validateDirectives(
+			schema,
+			field.Directives,
+			wantDirLocation,
+			nil,
+			true,
+		); err != nil {
 			return err
 		}
 	}
@@ -353,6 +366,7 @@ func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 				value.Directives,
 				LocationEnumValue,
 				nil,
+				true,
 			); err != nil {
 				return err
 			}
@@ -394,6 +408,19 @@ func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 		}
 	}
 
+	for idx, value1 := range def.EnumValues {
+		for _, value2 := range def.EnumValues[idx+1:] {
+			if value1.Name == value2.Name {
+				return gqlerror.ErrorPosf(
+					value2.Position,
+					"Enum value %s.%s can only be defined once.",
+					def.Name,
+					value2.Name,
+				)
+			}
+		}
+	}
+
 	if !def.BuiltIn {
 		// GraphQL spec has reserved type names a lot!
 		err := validateName(def.Position, def.Name)
@@ -402,7 +429,9 @@ func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 		}
 	}
 
-	return validateDirectives(schema, def.Directives, DirectiveLocation(def.Kind), nil)
+	// def.Directives is merged across the base definition and all extensions,
+	// which are distinct locations, so uniqueness is not enforced here.
+	return validateDirectives(schema, def.Directives, DirectiveLocation(def.Kind), nil, false)
 }
 
 func validateTypeRef(schema *Schema, typ *Type) *gqlerror.Error {
@@ -440,6 +469,7 @@ func validateArgs(
 			arg.Directives,
 			LocationArgumentDefinition,
 			currentDirective,
+			true,
 		); err != nil {
 			return err
 		}
@@ -452,7 +482,15 @@ func validateDirectives(
 	dirs DirectiveList,
 	location DirectiveLocation,
 	currentDirective *DirectiveDefinition,
+	// singleLocation is true when dirs come from a single authored location
+	// (one field, enum value, argument, or schema/extension node). A type's
+	// own directives are merged across its base definition and every extension
+	// (see the def.Directives append in LoadSchema), which the spec treats as
+	// distinct locations, so the non-repeatable check is skipped for that
+	// merged list to avoid rejecting a directive used once per location.
+	singleLocation bool,
 ) *gqlerror.Error {
+	seen := make(map[string]bool, len(dirs))
 	for _, dir := range dirs {
 		if err := validateName(dir.Position, dir.Name); err != nil {
 			// now, GraphQL spec doesn't have reserved directive name
@@ -468,6 +506,16 @@ func validateDirectives(
 		dirDefinition := schema.Directives[dir.Name]
 		if dirDefinition == nil {
 			return gqlerror.ErrorPosf(dir.Position, "Undefined directive %s.", dir.Name)
+		}
+		if singleLocation {
+			if seen[dir.Name] && !dirDefinition.IsRepeatable {
+				return gqlerror.ErrorPosf(
+					dir.Position,
+					"The directive %s can only be used once at this location.",
+					dir.Name,
+				)
+			}
+			seen[dir.Name] = true
 		}
 		validKind := slices.Contains(dirDefinition.Locations, location)
 		if !validKind {

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -445,6 +445,26 @@ enums:
     error:
       message: 'ENUM InvalidEnum2: must define one or more unique enum values.'
       locations: [{line: 6, column: 6}]
+  - name: cannot be duplicated enum value at same definition
+    input: |
+      enum A {
+        FOO
+        FOO
+      }
+    error:
+      message: "Enum value A.FOO can only be defined once."
+      locations: [{line: 3, column: 3}]
+  - name: cannot be duplicated enum value across extension
+    input: |
+      enum A {
+        FOO
+      }
+      extend enum A {
+        FOO
+      }
+    error:
+      message: "Enum value A.FOO can only be defined once."
+      locations: [{line: 5, column: 3}]
   - name: check reserved names on type name
     input: |
       enum __FooBar {
@@ -570,6 +590,45 @@ directives:
     error:
       message: "Directive A cannot refer to itself."
       locations: [{line: 1, column: 25}]
+
+  - name: non-repeatable directive cannot be used more than once per location
+    input: |
+      directive @A on FIELD_DEFINITION
+      type User {
+        name: String @A @A
+      }
+    error:
+      message: "The directive A can only be used once at this location."
+      locations: [{line: 3, column: 20}]
+  - name: non-repeatable directive cannot be used more than once on an enum value
+    input: |
+      directive @A on ENUM_VALUE
+      enum E {
+        FOO @A @A
+      }
+    error:
+      message: "The directive A can only be used once at this location."
+      locations: [{line: 3, column: 11}]
+  - name: repeatable directive can be used more than once per location
+    input: |
+      directive @A repeatable on FIELD_DEFINITION
+      type User {
+        name: String @A @A
+      }
+  - name: non-repeatable directive can be used on distinct locations
+    input: |
+      directive @A on FIELD_DEFINITION
+      type User {
+        a: String @A
+        b: String @A
+      }
+  - name: non-repeatable directive can be used on a type and its extension
+    input: |
+      directive @A on OBJECT
+      type User @A {
+        name: String
+      }
+      extend type User @A
   - name: check reserved names on type name
     input: |
       directive @__A on FIELD_DEFINITION


### PR DESCRIPTION
LoadSchema silently merged duplicate enum values (no uniqueness check), unlike object fields which already error with "Field X.Y can only be defined once." Add the equivalent check for enum values, reported as "Enum value X.Y can only be defined once."

Also enforce that a non-repeatable directive is applied at most once per schema location during schema validation (the executable-document rule in validator/rules already covers queries, but the type system was unchecked). The check is scoped to single authored locations via a singleLocation flag: a type's own directives are merged across its base definition and every extension, which the spec treats as distinct locations, so the merged list is exempt to avoid rejecting a directive used once per location.

Adds YAML cases covering duplicate enum values (same definition and across an extension), a repeated non-repeatable directive on a field and on an enum value, and positive cases (repeatable directive, the same directive on distinct locations, and a directive on a type plus its extension).

Fixes #435

Describe your PR and link to any relevant issues. 

I have:
 - [v] Added tests covering the bug / feature 
 - [v] Updated any relevant documentation
