### PR TITLE
fix nullable nested list variable coercion

### DIFF
--- a/validator/testdata/vars.graphql
+++ b/validator/testdata/vars.graphql
@@ -9,6 +9,7 @@ type Query {
     structArg(i: InputType!): Boolean!
     defaultStructArg(i: InputType! = {name: "foo"}): Boolean!
     arrayArg(i: [InputType!]): Boolean!
+    nestedArrayArg(i: [[InputType!]]): Boolean!
     intArrayArg(i: [Int]): Boolean!
     stringArrayArg(i: [String]): Boolean!
     boolArrayArg(i: [Boolean]): Boolean!

--- a/validator/vars.go
+++ b/validator/vars.go
@@ -117,6 +117,14 @@ func (v *varValidator) validateVarType(
 		v.path = currentPath
 	}
 	defer resetPath()
+
+	if !val.IsValid() {
+		if typ.NonNull {
+			return val, gqlerror.ErrorPathf(v.path, "cannot be null")
+		}
+		return val, nil
+	}
+
 	if typ.Elem != nil {
 		if val.Kind() != reflect.Slice {
 			// GraphQL spec says that non-null values should be coerced to an array when possible.
@@ -145,11 +153,6 @@ func (v *varValidator) validateVarType(
 	def := v.schema.Types[typ.NamedType]
 	if def == nil {
 		panic(fmt.Errorf("missing def for %s", typ.NamedType))
-	}
-
-	if !typ.NonNull && !val.IsValid() {
-		// If the type is not null and we got a invalid value namely null/nil, then it's valid
-		return val, nil
 	}
 
 	switch def.Kind {

--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -346,6 +346,37 @@ func TestValidateVars(t *testing.T) {
 			}}, vars["var"])
 		})
 
+		t.Run("null nested list value", func(t *testing.T) {
+			//nolint:staticcheck
+			q := gqlparser.MustLoadQuery(
+				schema,
+				`query foo($var: [[InputType!]]) { nestedArrayArg(i: $var) }`,
+			)
+			vars, gerr := validator.VariableValues(
+				schema,
+				q.Operations.ForName(""),
+				map[string]any{
+					"var": []any{
+						[]any{
+							map[string]any{
+								"name": "foo",
+							},
+						},
+						nil,
+					},
+				},
+			)
+			require.NoError(t, gerr)
+			require.EqualValues(t, []any{
+				[]any{
+					map[string]any{
+						"name": "foo",
+					},
+				},
+				nil,
+			}, vars["var"])
+		})
+
 		t.Run("null element value", func(t *testing.T) {
 			//nolint:staticcheck
 			q := gqlparser.MustLoadQuery(


### PR DESCRIPTION
Hello again! I'm the maintainer of [graphql-conformance](https://jbellenger.github.io/graphql-conformance/#), which verifies spec conformance across the GraphQL ecosystem.
 
I noticed that gqlgen had [a test failure](https://jbellenger.github.io/graphql-conformance/impl/gqlgen/failures/8fc8855d%2F0bfc42c4%2Ff68c37cc) that appears to originate in gqlparser.

The issue is that gqlparser does not handle valid null values when coercing nested lists.

For example, given this valid value for a type like `[[InputType!]]`:
```json
[
  [{ "name": "foo" }],
  null
]
```

The second element is a nullable inner list. gqlparser currently unwraps that null into an invalid `reflect.Value`, then panics when it tries to inspect the value's type:
```
reflect: call of reflect.Value.Type on zero Value
```

This PR fixes this by checking whether a reflected value represents null before trying to coerce it as a list or inspect its type. If the GraphQL type is nullable, the value is accepted; otherwise gqlparser returns the normal cannot be null validation error.

I have:
 - [x] Added tests covering the bug / feature 
 - [x] Updated any relevant documentation
