### PR TITLE
Reject duplicate union member types

### DIFF
--- a/validator/schema.go
+++ b/validator/schema.go
@@ -421,6 +421,19 @@ func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 		}
 	}
 
+	for idx, typ1 := range def.Types {
+		for _, typ2 := range def.Types[idx+1:] {
+			if typ1 == typ2 {
+				return gqlerror.ErrorPosf(
+					def.Position,
+					"Union type %s can only include type %s once.",
+					def.Name,
+					typ2,
+				)
+			}
+		}
+	}
+
 	if !def.BuiltIn {
 		// GraphQL spec has reserved type names a lot!
 		err := validateName(def.Position, def.Name)

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -494,6 +494,25 @@ unions:
     error:
       message: "UNION type \"Baz\" must be OBJECT."
       locations: [{line: 1, column: 7}]
+  - name: cannot include same union member twice at same definition
+    input: |
+      union Foo = Bar | Bar
+      type Bar {
+        id: ID
+      }
+    error:
+      message: "Union type Foo can only include type Bar once."
+      locations: [{line: 1, column: 7}]
+  - name: cannot include same union member twice across extension
+    input: |
+      union Foo = Bar
+      extend union Foo = Bar
+      type Bar {
+        id: ID
+      }
+    error:
+      message: "Union type Foo can only include type Bar once."
+      locations: [{line: 1, column: 7}]
 
   - name: unions of pure type extensions are valid
     input: |


### PR DESCRIPTION
The schema loader rejects duplicate enum values and duplicate field names, but `union Foo = A | A` with a repeated member loads silently (graphql-js rejects it). #436 added a duplicate-pair scan for EnumValues "mirroring the field check"; the third sibling — union member types (`def.Types`) — was left unchecked.

The fix mirrors the same duplicate scan to union members. A Go test reproduces it (expected an error, got none); the fix passes, the validator suite is green, 0 regression.