### PR TITLE
Improve duplicate union error message

### DIFF
--- a/ast/definition.go
+++ b/ast/definition.go
@@ -32,7 +32,13 @@ type Definition struct {
 	EnumValues  EnumValueList // enum
 
 	Position *Position `dump:"-" json:"-"`
-	BuiltIn  bool      `dump:"-"`
+	// TypePositions holds the source position of each Types entry (a union's
+	// member types), parallel to Types. The parser populates it so that
+	// validation can point at the offending member; when populated its length
+	// equals len(Types). It is empty for definitions built programmatically, in
+	// which case validators fall back to the definition's own Position.
+	TypePositions []*Position `dump:"-" json:"-"`
+	BuiltIn       bool        `dump:"-"`
 
 	BeforeDescriptionComment *CommentGroup
 	AfterDescriptionComment  *CommentGroup

--- a/ast/dumper.go
+++ b/ast/dumper.go
@@ -58,7 +58,7 @@ func (d *dumper) dump(v reflect.Value) {
 	case reflect.Array, reflect.Slice:
 		d.dumpArray(v)
 
-	case reflect.Interface, reflect.Ptr:
+	case reflect.Interface, reflect.Pointer:
 		d.dumpPtr(v)
 
 	case reflect.Struct:
@@ -79,7 +79,7 @@ func (d *dumper) nl() {
 }
 
 func typeName(t reflect.Type) string {
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		return typeName(t.Elem())
 	}
 	return t.Name()
@@ -122,7 +122,7 @@ func (d *dumper) dumpStruct(v reflect.Value) {
 
 func isZero(v reflect.Value) bool {
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		return v.IsNil()
 	case reflect.Func, reflect.Map:
 		return v.IsNil()

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -329,22 +329,26 @@ func (p *parser) parseUnionTypeDefinition(description descriptionWithComment) *D
 	def.AfterDescriptionComment = comment
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
-	def.Types = p.parseUnionMemberTypes()
+	def.Types, def.TypePositions = p.parseUnionMemberTypes()
 	return &def
 }
 
-func (p *parser) parseUnionMemberTypes() []string {
-	var types []string
+// parseUnionMemberTypes parses a union's member type list. It returns the member
+// type names alongside their source positions; the two slices have equal length
+// (one position per name), so callers can report errors at a specific member.
+func (p *parser) parseUnionMemberTypes() (types []string, positions []*Position) {
 	if p.skip(lexer.Equals) {
 		// optional leading pipe
 		p.skip(lexer.Pipe)
 
+		positions = append(positions, p.peekPos())
 		types = append(types, p.parseName())
 		for p.skip(lexer.Pipe) && p.err == nil {
+			positions = append(positions, p.peekPos())
 			types = append(types, p.parseName())
 		}
 	}
-	return types
+	return types, positions
 }
 
 func (p *parser) parseEnumTypeDefinition(description descriptionWithComment) *Definition {
@@ -506,7 +510,7 @@ func (p *parser) parseUnionTypeExtension(comment *CommentGroup) *Definition {
 	def.Kind = Union
 	def.Name = p.parseName()
 	def.Directives = p.parseDirectives(true)
-	def.Types = p.parseUnionMemberTypes()
+	def.Types, def.TypePositions = p.parseUnionMemberTypes()
 
 	if len(def.Directives) == 0 && len(def.Types) == 0 {
 		p.unexpectedError()

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -62,6 +62,7 @@ func ValidateSchemaDocument(sd *SchemaDocument) (*Schema, error) {
 		def.Interfaces = append(def.Interfaces, ext.Interfaces...)
 		def.Fields = append(def.Fields, ext.Fields...)
 		def.Types = append(def.Types, ext.Types...)
+		def.TypePositions = append(def.TypePositions, ext.TypePositions...)
 		def.EnumValues = append(def.EnumValues, ext.EnumValues...)
 	}
 
@@ -421,16 +422,26 @@ func validateDefinition(schema *Schema, def *Definition) *gqlerror.Error {
 		}
 	}
 
-	for idx, typ1 := range def.Types {
-		for _, typ2 := range def.Types[idx+1:] {
-			if typ1 == typ2 {
-				return gqlerror.ErrorPosf(
-					def.Position,
-					"Union type %s can only include type %s once.",
-					def.Name,
-					typ2,
-				)
+	// Reject duplicate union member types, pointing at the duplicate member's
+	// position when it is known. TypePositions is parallel to Types (populated by
+	// the parser); when it is absent or not aligned, fall back to the
+	// definition's own position.
+	memberPosAligned := len(def.TypePositions) == len(def.Types)
+	for i, typ1 := range def.Types {
+		for j := i + 1; j < len(def.Types); j++ {
+			if typ1 != def.Types[j] {
+				continue
 			}
+			pos := def.Position
+			if memberPosAligned && def.TypePositions[j] != nil {
+				pos = def.TypePositions[j]
+			}
+			return gqlerror.ErrorPosf(
+				pos,
+				"Union type %s can only include type %s once.",
+				def.Name,
+				def.Types[j],
+			)
 		}
 	}
 

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+	"github.com/vektah/gqlparser/v2/parser"
 	"github.com/vektah/gqlparser/v2/parser/testrunner"
 )
 
@@ -179,4 +180,33 @@ func TestSchemaDescriptionWithQuotesAtEnd(t *testing.T) {
 			"Schema with quotes at end of description should parse successfully",
 		)
 	})
+}
+
+func TestUnionDuplicateMemberFallbackPosition(t *testing.T) {
+	// When a union definition has no per-member TypePositions (e.g. it was built
+	// programmatically rather than parsed), duplicate detection falls back to the
+	// definition's own position instead of risking a misaligned member position.
+	// Simulate that by parsing a valid schema and clearing the positions.
+	sd, err := parser.ParseSchemas(
+		Prelude,
+		&ast.Source{Name: "t", Input: "union Foo = Bar | Bar\ntype Bar { id: ID }\n"},
+	)
+	require.NoError(t, err)
+	for _, def := range sd.Definitions {
+		if def.Name == "Foo" {
+			def.TypePositions = nil
+		}
+	}
+
+	_, err = ValidateSchemaDocument(sd)
+	require.Error(t, err)
+
+	var gerr *gqlerror.Error
+	require.ErrorAs(t, err, &gerr)
+	require.Contains(t, gerr.Message, "Union type Foo can only include type Bar once.")
+	// Falls back to the union definition's own position (line 1, column 7), not a
+	// member position.
+	require.Len(t, gerr.Locations, 1)
+	require.Equal(t, 1, gerr.Locations[0].Line)
+	require.Equal(t, 7, gerr.Locations[0].Column)
 }

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -502,7 +502,7 @@ unions:
       }
     error:
       message: "Union type Foo can only include type Bar once."
-      locations: [{line: 1, column: 7}]
+      locations: [{line: 1, column: 19}]
   - name: cannot include same union member twice across extension
     input: |
       union Foo = Bar
@@ -512,7 +512,19 @@ unions:
       }
     error:
       message: "Union type Foo can only include type Bar once."
-      locations: [{line: 1, column: 7}]
+      locations: [{line: 2, column: 20}]
+  - name: reports the second occurrence among multiple members
+    input: |
+      union Foo = Bar | Baz | Bar
+      type Bar {
+        id: ID
+      }
+      type Baz {
+        id: ID
+      }
+    error:
+      message: "Union type Foo can only include type Bar once."
+      locations: [{line: 1, column: 25}]
 
   - name: unions of pure type extensions are valid
     input: |

--- a/validator/vars.go
+++ b/validator/vars.go
@@ -86,7 +86,7 @@ func VariableValues(
 						rv = reflect.ValueOf(f)
 					}
 				}
-				if rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface {
+				if rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
 					rv = rv.Elem()
 				}
 
@@ -137,7 +137,7 @@ func (v *varValidator) validateVarType(
 			resetPath()
 			v.path = append(v.path, ast.PathIndex(i))
 			field := val.Index(i)
-			if field.Kind() == reflect.Ptr || field.Kind() == reflect.Interface {
+			if field.Kind() == reflect.Pointer || field.Kind() == reflect.Interface {
 				if typ.Elem.NonNull && field.IsNil() {
 					return val, gqlerror.ErrorPathf(v.path, "cannot be null")
 				}
@@ -248,7 +248,7 @@ func (v *varValidator) validateVarType(
 				continue
 			}
 
-			if field.Kind() == reflect.Ptr || field.Kind() == reflect.Interface {
+			if field.Kind() == reflect.Pointer || field.Kind() == reflect.Interface {
 				if fieldDef.Type.NonNull && field.IsNil() {
 					return val, gqlerror.ErrorPathf(v.path, "cannot be null")
 				}


### PR DESCRIPTION
Follow up to https://github.com/vektah/gqlparser/pull/442

###  validator: reject duplicate union member types

##  What

  Reject duplicate member types in a union definition, mirroring the existing duplicate-name checks for fields and enum values in validator/schema.go. Both of these previously
  loaded silently:

  union Foo = Bar | Bar        # duplicate within one definition
  extend union Foo = Bar       # duplicate introduced by an extension

  The base and extension member lists are merged (like Fields and EnumValues), but no uniqueness check followed. This adds one, producing:

  Union type Foo can only include type Bar once.

  matching graphql-js's UniqueUnionMemberTypes wording and the existing "… can only be defined once." idiom in this file.

  Error position

  The error points at the duplicate member itself (the second occurrence), consistent with how the field/enum checks report at the offending item — not at the union keyword. For
  the cross-extension case it points at the member in the extend block.

  Because union members are stored as []string (no per-member position), this adds an additive ast.Definition.TypePositions []*Position, parallel to Types, populated by the
  parser (tagged dump:"-" json:"-", so AST dumps/JSON are unchanged). When positions are absent — e.g. an AST built programmatically rather than parsed — validation falls back
  to the definition's own position. The fallback is guarded by a strict length-alignment check, so a partial/misaligned list degrades gracefully rather than mispointing.

  Compatibility

  Additive AST field; no public API changes. One behavior change worth calling out: a schema with a latent duplicate union member that previously loaded silently will now fail
  validation. This is spec-correct (graphql-js rejects it identically), but it can surface a pre-existing latent bug in a downstream schema on upgrade.

  Tests

  - validator/schema_test.yml: duplicate within one definition, duplicate across an extension, and a three-member case asserting the second occurrence is reported.
  - validator/schema_test.go: a position-less (programmatically built) definition falls back to the definition position.



Signed-off-by: Steve Coffman <steve@khanacademy.org>
