### PR TITLE
Fix default values for inline variable fields

### DIFF
--- a/ast/value.go
+++ b/ast/value.go
@@ -78,6 +78,12 @@ func (v *Value) Value(vars map[string]any) (any, error) {
 	case ObjectValue:
 		val := map[string]any{}
 		for _, elem := range v.Children {
+			if elem.Value.Kind == Variable {
+				if _, ok := vars[elem.Value.Raw]; !ok &&
+					(elem.Value.VariableDefinition == nil || elem.Value.VariableDefinition.DefaultValue == nil) {
+					continue
+				}
+			}
 			elemVal, err := elem.Value.Value(vars)
 			if err != nil {
 				return val, err

--- a/ast/value.go
+++ b/ast/value.go
@@ -42,6 +42,18 @@ type ChildValue struct {
 	Comment  *CommentGroup
 }
 
+// isUnsetVariable reports whether v is a variable reference with no supplied
+// value and no default — it should be treated as absent, not null.
+func (v *Value) isUnsetVariable(vars map[string]any) bool {
+	if v.Kind != Variable {
+		return false
+	}
+	if _, ok := vars[v.Raw]; ok {
+		return false
+	}
+	return v.VariableDefinition == nil || v.VariableDefinition.DefaultValue == nil
+}
+
 func (v *Value) Value(vars map[string]any) (any, error) {
 	if v == nil {
 		return nil, nil
@@ -78,11 +90,8 @@ func (v *Value) Value(vars map[string]any) (any, error) {
 	case ObjectValue:
 		val := map[string]any{}
 		for _, elem := range v.Children {
-			if elem.Value.Kind == Variable {
-				if _, ok := vars[elem.Value.Raw]; !ok &&
-					(elem.Value.VariableDefinition == nil || elem.Value.VariableDefinition.DefaultValue == nil) {
-					continue
-				}
+			if elem.Value.isUnsetVariable(vars) {
+				continue
 			}
 			elemVal, err := elem.Value.Value(vars)
 			if err != nil {

--- a/ast/value_test.go
+++ b/ast/value_test.go
@@ -1,0 +1,30 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValueObject(t *testing.T) {
+	t.Run("undefined variable", func(t *testing.T) {
+		obj := &Value{Kind: ObjectValue, Children: ChildValueList{
+			{Name: "field", Value: &Value{Kind: Variable, Raw: "Var"}},
+		}}
+		val, err := obj.Value(map[string]any{})
+		require.NoError(t, err)
+		// Treated as absent so the field's own default can be applied later.
+		require.NotContains(t, val.(map[string]any), "field")
+	})
+
+	t.Run("explicit null", func(t *testing.T) {
+		obj := &Value{Kind: ObjectValue, Children: ChildValueList{
+			{Name: "field", Value: &Value{Kind: NullValue}},
+		}}
+		val, err := obj.Value(map[string]any{})
+		require.NoError(t, err)
+		m := val.(map[string]any)
+		require.Contains(t, m, "field")
+		require.Nil(t, m["field"])
+	})
+}

--- a/ast/value_test.go
+++ b/ast/value_test.go
@@ -17,6 +17,26 @@ func TestValueObject(t *testing.T) {
 		require.NotContains(t, val.(map[string]any), "field")
 	})
 
+	t.Run("undefined variable with default", func(t *testing.T) {
+		// The variable is not supplied in vars, but its definition carries a
+		// default value, so the field is present with that default.
+		obj := &Value{Kind: ObjectValue, Children: ChildValueList{
+			{Name: "field", Value: &Value{
+				Kind: Variable,
+				Raw:  "Var",
+				VariableDefinition: &VariableDefinition{
+					Variable:     "Var",
+					DefaultValue: &Value{Kind: IntValue, Raw: "42"},
+				},
+			}},
+		}}
+		val, err := obj.Value(map[string]any{})
+		require.NoError(t, err)
+		m := val.(map[string]any)
+		require.Contains(t, m, "field")
+		require.Equal(t, int64(42), m["field"])
+	})
+
 	t.Run("explicit null", func(t *testing.T) {
 		obj := &Value{Kind: ObjectValue, Children: ChildValueList{
 			{Name: "field", Value: &Value{Kind: NullValue}},


### PR DESCRIPTION
When an input object field is set inline from a variable (e.g. { truthyBoolean: $truthyBoolean }) and that variable is left undefined, the schema's default value for the field isn't applied. Instead, the resolver receives nil. If the entire input object is passed as a variable, or if the field is omitted altogether, the default is applied as expected. This behavior is inconsistent.

In the ObjectValue branch, skip a child whose value is a variable that is neither present in vars nor has it’s own default value, so the field is treated as absent.

Fixes #347
The reproduction and downstream impact are described in: https://github.com/99designs/gqlgen/issues/4263

I have:
 - [X] Added tests covering the bug / feature 
 - [ ] Updated any relevant documentation: N/A — no docs affected
