### PR TITLE
feat(gqlerror): add Error.Is for errors.Is support

### DIFF
--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -80,8 +80,8 @@ func (err *Error) Is(target error) bool {
 		return target == nil
 	}
 
-	var gqlErr *Error
-	if !errors.As(target, &gqlErr) || gqlErr == nil {
+	gqlErr, ok := target.(*Error)
+	if !ok || gqlErr == nil {
 		return false
 	}
 

--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -3,6 +3,7 @@ package gqlerror
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -72,6 +73,23 @@ func (err *Error) pathString() string {
 
 func (err *Error) Unwrap() error {
 	return err.Err
+}
+
+func (err *Error) Is(target error) bool {
+	if err == nil {
+		return target == nil
+	}
+
+	var gqlErr *Error
+	if !errors.As(target, &gqlErr) || gqlErr == nil {
+		return false
+	}
+
+	return err.Message == gqlErr.Message &&
+		err.Rule == gqlErr.Rule &&
+		reflect.DeepEqual(err.Path, gqlErr.Path) &&
+		reflect.DeepEqual(err.Locations, gqlErr.Locations) &&
+		reflect.DeepEqual(err.Extensions, gqlErr.Extensions)
 }
 
 func (err *Error) AsError() error {

--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -75,6 +75,8 @@ func (err *Error) Unwrap() error {
 	return err.Err
 }
 
+// Is reports whether target has the same Message, Rule, Path, Locations, and
+// Extensions. The wrapped Err is intentionally not compared.
 func (err *Error) Is(target error) bool {
 	if err == nil {
 		return target == nil
@@ -108,6 +110,8 @@ func (errs List) Error() string {
 	return buf.String()
 }
 
+// Is reports whether any error in the list matches target according to
+// errors.Is, including structural matches defined by Error.Is.
 func (errs List) Is(target error) bool {
 	for _, err := range errs {
 		if errors.Is(err, target) {

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -1,6 +1,7 @@
 package gqlerror
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -66,6 +67,97 @@ func TestErrorPosition(t *testing.T) {
 		require.Nil(t, err.Extensions["file"])
 		require.Nil(t, errNilPosition.Extensions["file"])
 	})
+}
+
+func TestError_Is(t *testing.T) {
+	t.Parallel()
+
+	matchingPath := ast.Path{ast.PathName("query"), ast.PathIndex(1)}
+	matchingLocations := []Location{{Line: 2, Column: 3}}
+	matchingExtensions := map[string]any{"code": "INVALID", "nested": []string{"a", "b"}}
+
+	tests := []struct {
+		name    string
+		err     *Error
+		target  error
+		want    bool
+		reverse bool
+	}{
+		{
+			name:    "identical messages",
+			err:     &Error{Message: "invalid query"},
+			target:  &Error{Message: "invalid query"},
+			want:    true,
+			reverse: true,
+		},
+		{
+			name: "identical fields",
+			err: &Error{
+				Message:    "invalid query",
+				Rule:       "KnownTypeNames",
+				Path:       matchingPath,
+				Locations:  matchingLocations,
+				Extensions: matchingExtensions,
+			},
+			target: &Error{
+				Message:    "invalid query",
+				Rule:       "KnownTypeNames",
+				Path:       ast.Path{ast.PathName("query"), ast.PathIndex(1)},
+				Locations:  []Location{{Line: 2, Column: 3}},
+				Extensions: map[string]any{"code": "INVALID", "nested": []string{"a", "b"}},
+			},
+			want:    true,
+			reverse: true,
+		},
+		{
+			name:   "different message",
+			err:    &Error{Message: "first"},
+			target: &Error{Message: "second"},
+		},
+		{
+			name:   "different rule",
+			err:    &Error{Message: "invalid", Rule: "RuleA"},
+			target: &Error{Message: "invalid", Rule: "RuleB"},
+		},
+		{
+			name:   "different path",
+			err:    &Error{Message: "invalid", Path: ast.Path{ast.PathName("a")}},
+			target: &Error{Message: "invalid", Path: ast.Path{ast.PathName("b")}},
+		},
+		{
+			name:   "different locations",
+			err:    &Error{Message: "invalid", Locations: []Location{{Line: 1, Column: 1}}},
+			target: &Error{Message: "invalid", Locations: []Location{{Line: 1, Column: 2}}},
+		},
+		{
+			name:   "different extensions",
+			err:    &Error{Message: "invalid", Extensions: map[string]any{"code": "A"}},
+			target: &Error{Message: "invalid", Extensions: map[string]any{"code": "B"}},
+		},
+		{
+			name:   "wrapped non gqlerror target",
+			err:    &Error{Err: underlyingError, Message: "wrapped"},
+			target: underlyingError,
+			want:   true,
+		},
+		{
+			name: "nil target",
+			err:  &Error{Message: "invalid"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, errors.Is(tt.err, tt.target))
+			if tt.reverse {
+				require.Equal(t, tt.want, errors.Is(tt.target, tt.err))
+			}
+		})
+	}
+
+	var nilErr *Error
+	require.True(t, nilErr.Is(nil))
 }
 
 func TestList_As(t *testing.T) {

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -2,6 +2,7 @@ package gqlerror
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -158,6 +159,14 @@ func TestError_Is(t *testing.T) {
 
 	var nilErr *Error
 	require.True(t, nilErr.Is(nil))
+
+	t.Run("does not match wrapped target", func(t *testing.T) {
+		err := &Error{Message: "invalid query"}
+		equivalent := &Error{Message: "invalid query"}
+
+		require.True(t, errors.Is(err, equivalent))
+		require.False(t, errors.Is(err, fmt.Errorf("ctx: %w", equivalent)))
+	})
 }
 
 func TestList_As(t *testing.T) {

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -164,8 +164,8 @@ func TestError_Is(t *testing.T) {
 		err := &Error{Message: "invalid query"}
 		equivalent := &Error{Message: "invalid query"}
 
-		require.True(t, errors.Is(err, equivalent))
-		require.False(t, errors.Is(err, fmt.Errorf("ctx: %w", equivalent)))
+		require.ErrorIs(t, err, equivalent)
+		require.NotErrorIs(t, err, fmt.Errorf("ctx: %w", equivalent))
 	})
 }
 
@@ -262,6 +262,14 @@ func TestList_Is(t *testing.T) {
 				error2,
 			},
 			target:           underlyingError,
+			hasMatchingError: true,
+		},
+		{
+			name: "List with structurally matching error",
+			errs: List{
+				{Message: "invalid query"},
+			},
+			target:           &Error{Message: "invalid query"},
 			hasMatchingError: true,
 		},
 	}


### PR DESCRIPTION
## Summary

`*gqlerror.Error` now implements `Is(error) bool`, so two structurally-equal gqlerrors compare as equal under `errors.Is` (and `cmpopts.EquateErrors`, which is built on it). Previously `errors.Is` fell back to pointer identity, so two errors carrying identical fields but distinct instances never matched.

## Background

The gqlerror package already ships a `List.Is` method, so `Error.Is` completes that pattern; #249 requested it and a maintainer replied "Excellent idea! PR welcome!". The method declines non-`*Error` targets (letting `errors.Is` keep walking the receiver's `Unwrap` chain) and, for a `*Error` target, compares the identifying fields the issue means by "the same fields": `Message`, `Rule`, `Path`, `Locations`, and `Extensions`. The private wrapped cause (`Err`) is intentionally left to the existing `Unwrap` chain rather than folded into `Is`, and the comparison is against the direct target only (not the target's unwrap chain), matching Go's `errors.Is` semantics. A nil receiver is guarded.

I have:
- [x] Added tests covering the bug / feature
- [x] Updated any relevant documentation (N/A - matches the existing undocumented `List.Is`/`List.As` style)

Closes #249
