### PR TITLE
fix(validator): Reject non-null input cycles

### DIFF
--- a/validator/schema.go
+++ b/validator/schema.go
@@ -189,6 +189,10 @@ func ValidateSchemaDocument(sd *SchemaDocument) (*Schema, error) {
 		return nil, err
 	}
 
+	if err := validateInputObjectCircularRefs(&schema); err != nil {
+		return nil, err
+	}
+
 	if err := validateDirectiveDefinitions(&schema); err != nil {
 		return nil, err
 	}
@@ -239,6 +243,75 @@ func validateTypeDefinitions(schema *Schema) *gqlerror.Error {
 	for _, typ := range types {
 		err := validateDefinition(schema, schema.Types[typ])
 		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateInputObjectCircularRefs rejects input object cycles of non-null fields.
+// https://spec.graphql.org/October2021/#sec-Input-Objects.Circular-References
+func validateInputObjectCircularRefs(schema *Schema) *gqlerror.Error {
+	types := make([]string, 0, len(schema.Types))
+	for typ := range schema.Types {
+		types = append(types, typ)
+	}
+	sort.Strings(types)
+
+	// A type still on fieldPath means a cycle. A visited type was already checked.
+	visited := make(map[string]bool, len(schema.Types))
+	fieldPath := make([]*FieldDefinition, 0, len(schema.Types))
+	fieldPathIndexByTypeName := make(map[string]int, len(schema.Types))
+
+	var detectCycle func(def *Definition) *gqlerror.Error
+	detectCycle = func(def *Definition) *gqlerror.Error {
+		if visited[def.Name] {
+			return nil
+		}
+		visited[def.Name] = true
+		fieldPathIndexByTypeName[def.Name] = len(fieldPath)
+
+		for _, field := range def.Fields {
+			// A nullable field or any list breaks the chain.
+			if !field.Type.NonNull || field.Type.NamedType == "" {
+				continue
+			}
+			fieldType := schema.Types[field.Type.NamedType]
+			if fieldType == nil || fieldType.Kind != InputObject {
+				continue
+			}
+
+			fieldPath = append(fieldPath, field)
+			if cycleIndex, ok := fieldPathIndexByTypeName[fieldType.Name]; ok {
+				cyclePath := fieldPath[cycleIndex:]
+				fieldNames := make([]string, len(cyclePath))
+				for i, cycleField := range cyclePath {
+					fieldNames[i] = cycleField.Name
+				}
+				return gqlerror.ErrorPosf(
+					cyclePath[0].Position,
+					"Cannot reference Input Object %s within itself through "+
+						"a series of non-null fields: %s.",
+					strconv.Quote(fieldType.Name),
+					strconv.Quote(strings.Join(fieldNames, ".")),
+				)
+			}
+			if err := detectCycle(fieldType); err != nil {
+				return err
+			}
+			fieldPath = fieldPath[:len(fieldPath)-1]
+		}
+
+		delete(fieldPathIndexByTypeName, def.Name)
+		return nil
+	}
+
+	for _, typ := range types {
+		def := schema.Types[typ]
+		if def.Kind != InputObject {
+			continue
+		}
+		if err := detectCycle(def); err != nil {
 			return err
 		}
 	}

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -386,6 +386,116 @@ inputs:
       message: 'UNION a: field must be one of SCALAR, ENUM, INPUT_OBJECT.'
       locations: [{line: 3, column: 13}]
 
+  - name: cannot reference itself through a non-null field
+    input: |
+      input T {
+        self: T!
+      }
+    error:
+      message: 'Cannot reference Input Object "T" within itself through a series of non-null fields: "self".'
+      locations: [{line: 2, column: 3}]
+
+  - name: cannot reference itself through a chain of non-null fields
+    input: |
+      input A {
+        startLoop: B!
+      }
+      input B {
+        nextInLoop: C!
+      }
+      input C {
+        closeLoop: A!
+      }
+    error:
+      message: 'Cannot reference Input Object "A" within itself through a series of non-null fields: "startLoop.nextInLoop.closeLoop".'
+      locations: [{line: 2, column: 3}]
+
+  - name: cannot reference itself through a non-null field added by an extension
+    input: |
+      input T {
+        id: ID
+      }
+      extend input T {
+        self: T!
+      }
+    error:
+      message: 'Cannot reference Input Object "T" within itself through a series of non-null fields: "self".'
+      locations: [{line: 5, column: 3}]
+
+  - name: cannot reference itself through a non-null field on a nested cycle
+    input: |
+      input Outer {
+        inner: Inner!
+      }
+      input Inner {
+        self: Inner!
+      }
+    error:
+      message: 'Cannot reference Input Object "Inner" within itself through a series of non-null fields: "self".'
+      locations: [{line: 5, column: 3}]
+
+  - name: cannot reference itself when an earlier input object is cycle free
+    input: |
+      input Entry {
+        maybe: Loop
+      }
+      input Loop {
+        self: Loop!
+      }
+    error:
+      message: 'Cannot reference Input Object "Loop" within itself through a series of non-null fields: "self".'
+      locations: [{line: 5, column: 3}]
+
+  - name: can reference itself through a nullable field
+    input: |
+      input T {
+        self: T
+      }
+
+  - name: can reference itself through a list field
+    input: |
+      input T {
+        a: [T!]!
+        b: [T]!
+        c: [T!]
+        d: [T]
+        e: [[T!]!]!
+      }
+
+  - name: can reference itself when the chain is broken by a list
+    input: |
+      input A {
+        startLoop: B!
+      }
+      input B {
+        loopBack: [A!]!
+      }
+
+  - name: can reference itself when the chain is broken by a nullable field
+    input: |
+      input A {
+        startLoop: B!
+      }
+      input B {
+        nextInLoop: C
+      }
+      input C {
+        closeLoop: A!
+      }
+
+  - name: can reference the same input object twice without a cycle
+    input: |
+      input A {
+        b: B!
+        c: C!
+      }
+      input B {
+        c: C!
+      }
+      input C {
+        id: ID!
+      }
+
 args:
   - name: Valid arg types
     input: |


### PR DESCRIPTION
Reject input object cycles of non-null fields, according to: https://spec.graphql.org/October2021/#sec-Input-Objects.Circular-References

Schemas containing a non-null cycle now correctly fail validation.

I have:
 - [x] Added tests covering the bug / feature 
 - [x] Updated any relevant documentation

Fixes #239