### PR TITLE
Compare composite argument values in `sameValue` (#108)

### DIFF
--- a/validator/rules/overlapping_fields_can_be_merged.go
+++ b/validator/rules/overlapping_fields_can_be_merged.go
@@ -577,6 +577,30 @@ func sameValue(value1, value2 *ast.Value) bool {
 	if value1.Raw != value2.Raw {
 		return false
 	}
+	// Object and list values keep their contents in Children with an empty Raw, so
+	// the Raw comparison above is not enough to tell them apart. Compare the children
+	// too, otherwise every object (or list) value looks equal to every other one and
+	// fields with differing composite arguments are wrongly allowed to merge.
+	if len(value1.Children) != len(value2.Children) {
+		return false
+	}
+	switch value1.Kind {
+	case ast.ObjectValue:
+		// Input object field order is not significant, so match children by name.
+		for _, child1 := range value1.Children {
+			child2 := value2.Children.ForName(child1.Name)
+			if child2 == nil || !sameValue(child1.Value, child2) {
+				return false
+			}
+		}
+	default:
+		// List (and any other composite) values are compared position by position.
+		for i := range value1.Children {
+			if !sameValue(value1.Children[i].Value, value2.Children[i].Value) {
+				return false
+			}
+		}
+	}
 	return true
 }
 

--- a/validator/rules/overlapping_fields_can_be_merged_test.go
+++ b/validator/rules/overlapping_fields_can_be_merged_test.go
@@ -141,3 +141,78 @@ func Test_sameArguments(t *testing.T) {
 		})
 	}
 }
+
+func Test_sameValue(t *testing.T) {
+	str := func(raw string) *ast.Value {
+		return &ast.Value{Kind: ast.StringValue, Raw: raw}
+	}
+	object := func(fields ...*ast.ChildValue) *ast.Value {
+		return &ast.Value{Kind: ast.ObjectValue, Children: ast.ChildValueList(fields)}
+	}
+	field := func(name string, v *ast.Value) *ast.ChildValue {
+		return &ast.ChildValue{Name: name, Value: v}
+	}
+	list := func(elems ...*ast.Value) *ast.Value {
+		children := make(ast.ChildValueList, len(elems))
+		for i, e := range elems {
+			children[i] = &ast.ChildValue{Value: e}
+		}
+		return &ast.Value{Kind: ast.ListValue, Children: children}
+	}
+
+	tests := map[string]struct {
+		value1, value2 *ast.Value
+		result         bool
+	}{
+		"identical scalars": {str("DE"), str("DE"), true},
+		"different scalars":  {str("DE"), str("US"), false},
+		// Regression for #108: object arguments are stored in Children with an empty
+		// Raw, so differing objects used to compare equal and merge incorrectly.
+		"objects with differing field values": {
+			object(field("code", str("DE"))),
+			object(field("code", str("US"))),
+			false,
+		},
+		"identical objects": {
+			object(field("code", str("DE"))),
+			object(field("code", str("DE"))),
+			true,
+		},
+		// Input object field order is not significant.
+		"objects with same fields in different order": {
+			object(field("code", str("DE")), field("name", str("Germany"))),
+			object(field("name", str("Germany")), field("code", str("DE"))),
+			true,
+		},
+		"objects with different field count": {
+			object(field("code", str("DE"))),
+			object(field("code", str("DE")), field("name", str("Germany"))),
+			false,
+		},
+		// Regression for #108: same for list arguments.
+		"lists with differing elements": {
+			list(str("DE")),
+			list(str("US")),
+			false,
+		},
+		"identical lists": {
+			list(str("DE"), str("US")),
+			list(str("DE"), str("US")),
+			true,
+		},
+		// List element order is significant.
+		"lists with same elements in different order": {
+			list(str("DE"), str("US")),
+			list(str("US"), str("DE")),
+			false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := sameValue(tc.value1, tc.value2); got != tc.result {
+				t.Fatalf("Expected %t got %t", tc.result, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Fixes #108. `OverlappingFieldsCanBeMerged` fails to flag same-response-name fields whose **object or list** arguments differ, so genuinely conflicting queries pass validation:

```graphql
{
  a: country(where: { code: "DE" })
  a: country(where: { code: "US" })   # should conflict, but is allowed to merge
}
```

## Why

`sameValue` compares only `Kind` and `Raw`:

```go
func sameValue(value1, value2 *ast.Value) bool {
    if value1.Kind != value2.Kind { return false }
    if value1.Raw != value2.Raw { return false }
    return true
}
```

But in the AST, **object and list values keep their contents in `Children` and leave `Raw` empty** (see `ast/value.go`). So every `ObjectValue` compares equal to every other `ObjectValue`, and likewise for lists. Per the GraphQL spec (§5.3.2, *Field Selection Merging*), fields sharing a response name must have identical arguments — a deep input-value comparison — or be aliased. Ignoring the children silently permits ambiguous queries to merge.

## How

After the existing `Kind`/`Raw` checks, compare the children too:

- **Input objects** — field order is *not* significant (spec), so match children by name via the existing `ChildValueList.ForName`.
- **Lists** (and any other composite) — order *is* significant, so compare position by position.

Scalars are unaffected (they carry no children, so the loop is a no-op and the `Raw` check still decides).

## Tests

Added `Test_sameValue` to `overlapping_fields_can_be_merged_test.go`, covering:
- identical/different scalars (baseline);
- objects with differing field values → not equal (**fails without this change**);
- identical objects, and objects with the same fields in a different order → equal;
- objects with a different field count → not equal;
- lists with differing elements → not equal (**fails without this change**);
- identical lists, and lists with the same elements reordered → not equal (order-sensitive).

`go test ./...` passes across the module, including the imported graphql-js spec suite (which covers *allows different order of input object fields in arg values*).

---

*Disclosure: this change was prepared with AI assistance and reviewed/verified by me before submission.*