### PR TITLE
gqlerror: retain sources for validation error locations

### DIFF
--- a/gqlerror/compatibility_test.go
+++ b/gqlerror/compatibility_test.go
@@ -26,3 +26,9 @@ func TestSourceLocationsAreAvailableOutsidePackage(t *testing.T) {
 	require.Equal(t, gqlerror.Location{Line: 1, Column: 2}, locations[0].Location)
 	require.Same(t, source, locations[0].Source)
 }
+
+func TestErrorSupportsKeyedLiteral(t *testing.T) {
+	err := gqlerror.Error{Message: "kabloom"}
+
+	require.Equal(t, "kabloom", err.Message)
+}

--- a/gqlerror/compatibility_test.go
+++ b/gqlerror/compatibility_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
@@ -13,4 +14,15 @@ func TestLocationSupportsUnkeyedLiteral(t *testing.T) {
 
 	require.Equal(t, 1, location.Line)
 	require.Equal(t, 2, location.Column)
+}
+
+func TestSourceLocationsAreAvailableOutsidePackage(t *testing.T) {
+	source := &ast.Source{Name: "query.graphql"}
+	err := &gqlerror.Error{}
+	err.AddLocation(gqlerror.Location{Line: 1, Column: 2}, source)
+
+	locations := err.SourceLocations()
+	require.Len(t, locations, 1)
+	require.Equal(t, gqlerror.Location{Line: 1, Column: 2}, locations[0].Location)
+	require.Same(t, source, locations[0].Source)
 }

--- a/gqlerror/compatibility_test.go
+++ b/gqlerror/compatibility_test.go
@@ -1,0 +1,16 @@
+package gqlerror_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+func TestLocationSupportsUnkeyedLiteral(t *testing.T) {
+	location := gqlerror.Location{1, 2}
+
+	require.Equal(t, 1, location.Line)
+	require.Equal(t, 2, location.Column)
+}

--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -47,10 +47,10 @@ func (err *Error) Error() string {
 		return ""
 	}
 	filename := ""
-	if len(err.LocationSources) > 0 && err.LocationSources[0] != nil {
+	hasPrimarySource := len(err.LocationSources) > 0 && err.LocationSources[0] != nil
+	if hasPrimarySource {
 		filename = err.LocationSources[0].Name
-	}
-	if filename == "" {
+	} else {
 		filename, _ = err.Extensions["file"].(string)
 	}
 	if filename == "" {

--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -46,6 +46,13 @@ type SourceLocation struct {
 // AddLocation appends a location to the GraphQL response and its source-aware
 // representation.
 func (err *Error) AddLocation(location Location, source *ast.Source) {
+	err.validateSourceLocations()
+	if len(err.sourceLocations) == 0 && len(err.Locations) > 0 {
+		err.sourceLocations = make([]SourceLocation, len(err.Locations))
+		for i, existing := range err.Locations {
+			err.sourceLocations[i].Location = existing
+		}
+	}
 	err.Locations = append(err.Locations, location)
 	err.sourceLocations = append(err.sourceLocations, SourceLocation{
 		Location: location,
@@ -54,14 +61,34 @@ func (err *Error) AddLocation(location Location, source *ast.Source) {
 }
 
 // SourceLocations returns a shallow copy of the source-aware locations in
-// validation order.
+// validation order. It panics when Locations changed independently after a
+// source-aware location was added.
 func (err *Error) SourceLocations() []SourceLocation {
 	if err == nil {
 		return nil
 	}
+	err.validateSourceLocations()
 	locations := make([]SourceLocation, len(err.sourceLocations))
 	copy(locations, err.sourceLocations)
 	return locations
+}
+
+func (err *Error) validateSourceLocations() {
+	if len(err.sourceLocations) == 0 {
+		return
+	}
+	if len(err.sourceLocations) != len(err.Locations) {
+		panic(fmt.Sprintf(
+			"gqlerror: location count %d does not match source location count %d",
+			len(err.Locations),
+			len(err.sourceLocations),
+		))
+	}
+	for i, sourceLocation := range err.sourceLocations {
+		if sourceLocation.Location != err.Locations[i] {
+			panic(fmt.Sprintf("gqlerror: location %d changed independently of its source", i))
+		}
+	}
 }
 
 type List []*Error
@@ -71,11 +98,13 @@ func (err *Error) Error() string {
 	if err == nil {
 		return ""
 	}
+	err.validateSourceLocations()
 	filename := ""
-	hasPrimarySource := len(err.sourceLocations) > 0 && err.sourceLocations[0].Source != nil
-	if hasPrimarySource {
+	if len(err.sourceLocations) == 0 {
+		filename, _ = err.Extensions["file"].(string)
+	} else if err.sourceLocations[0].Source != nil {
 		filename = err.sourceLocations[0].Source.Name
-	} else {
+	} else if len(err.sourceLocations) == 1 {
 		filename, _ = err.Extensions["file"].(string)
 	}
 	if filename == "" {

--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -17,6 +17,7 @@ type Error struct {
 	Locations []Location `json:"locations,omitempty"`
 	// LocationSources aligns source documents with Locations by index. An entry
 	// may be nil when the corresponding location has no source document.
+	// Keeping the sources on Error preserves Location's two-field literal shape.
 	LocationSources []*ast.Source  `json:"-"`
 	Extensions      map[string]any `json:"extensions,omitempty"`
 	Rule            string         `json:"-"`

--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -33,6 +33,10 @@ func (err *Error) SetFile(file string) {
 type Location struct {
 	Line   int `json:"line,omitempty"`
 	Column int `json:"column,omitempty"`
+	// Source identifies the source document containing this location. It is
+	// intentionally omitted from the GraphQL response representation, which
+	// only carries line and column for each location.
+	Source *ast.Source `json:"-"`
 }
 
 type List []*Error
@@ -174,13 +178,15 @@ func ErrorPosf(pos *ast.Position, message string, args ...any) *Error {
 			args...,
 		)
 	}
-	return ErrorLocf(
+	err := ErrorLocf(
 		pos.Src.Name,
 		pos.Line,
 		pos.Column,
 		message,
 		args...,
 	)
+	err.Locations[0].Source = pos.Src
+	return err
 }
 
 func ErrorLocf(file string, line, col int, message string, args ...any) *Error {

--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -11,12 +11,15 @@ import (
 
 // Error is the standard graphql error type described in https://spec.graphql.org/draft/#sec-Errors
 type Error struct {
-	Err        error          `json:"-"`
-	Message    string         `json:"message"`
-	Path       ast.Path       `json:"path,omitempty"`
-	Locations  []Location     `json:"locations,omitempty"`
-	Extensions map[string]any `json:"extensions,omitempty"`
-	Rule       string         `json:"-"`
+	Err       error      `json:"-"`
+	Message   string     `json:"message"`
+	Path      ast.Path   `json:"path,omitempty"`
+	Locations []Location `json:"locations,omitempty"`
+	// LocationSources aligns source documents with Locations by index. An entry
+	// may be nil when the corresponding location has no source document.
+	LocationSources []*ast.Source  `json:"-"`
+	Extensions      map[string]any `json:"extensions,omitempty"`
+	Rule            string         `json:"-"`
 }
 
 func (err *Error) SetFile(file string) {
@@ -33,10 +36,6 @@ func (err *Error) SetFile(file string) {
 type Location struct {
 	Line   int `json:"line,omitempty"`
 	Column int `json:"column,omitempty"`
-	// Source identifies the source document containing this location. It is
-	// intentionally omitted from the GraphQL response representation, which
-	// only carries line and column for each location.
-	Source *ast.Source `json:"-"`
 }
 
 type List []*Error
@@ -46,7 +45,13 @@ func (err *Error) Error() string {
 	if err == nil {
 		return ""
 	}
-	filename, _ := err.Extensions["file"].(string)
+	filename := ""
+	if len(err.LocationSources) > 0 && err.LocationSources[0] != nil {
+		filename = err.LocationSources[0].Name
+	}
+	if filename == "" {
+		filename, _ = err.Extensions["file"].(string)
+	}
 	if filename == "" {
 		filename = "input"
 	}
@@ -185,7 +190,7 @@ func ErrorPosf(pos *ast.Position, message string, args ...any) *Error {
 		message,
 		args...,
 	)
-	err.Locations[0].Source = pos.Src
+	err.LocationSources = []*ast.Source{pos.Src}
 	return err
 }
 

--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -1,6 +1,7 @@
 package gqlerror
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -74,7 +75,7 @@ func (err *Error) SourceLocations() []SourceLocation {
 }
 
 func (err *Error) validateSourceLocations() {
-	if len(err.sourceLocations) == 0 {
+	if err.sourceLocationsMatch() {
 		return
 	}
 	if len(err.sourceLocations) != len(err.Locations) {
@@ -91,6 +92,29 @@ func (err *Error) validateSourceLocations() {
 	}
 }
 
+func (err *Error) sourceLocationsMatch() bool {
+	if len(err.sourceLocations) == 0 {
+		return true
+	}
+	if len(err.sourceLocations) != len(err.Locations) {
+		return false
+	}
+	for i, sourceLocation := range err.sourceLocations {
+		if sourceLocation.Location != err.Locations[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// UnmarshalJSON discards source documents because GraphQL error JSON does not
+// encode them.
+func (err *Error) UnmarshalJSON(data []byte) error {
+	type errorWithoutMethods Error
+	err.sourceLocations = nil
+	return json.Unmarshal(data, (*errorWithoutMethods)(err))
+}
+
 type List []*Error
 
 func (err *Error) Error() string {
@@ -98,14 +122,20 @@ func (err *Error) Error() string {
 	if err == nil {
 		return ""
 	}
-	err.validateSourceLocations()
+	sourceLocations := err.sourceLocations
+	if !err.sourceLocationsMatch() {
+		sourceLocations = nil
+	}
 	filename := ""
-	if len(err.sourceLocations) == 0 {
+	if len(sourceLocations) == 0 {
 		filename, _ = err.Extensions["file"].(string)
-	} else if err.sourceLocations[0].Source != nil {
-		filename = err.sourceLocations[0].Source.Name
-	} else if len(err.sourceLocations) == 1 {
+	} else if len(sourceLocations) == 1 {
 		filename, _ = err.Extensions["file"].(string)
+		if filename == "" && sourceLocations[0].Source != nil {
+			filename = sourceLocations[0].Source.Name
+		}
+	} else if sourceLocations[0].Source != nil {
+		filename = sourceLocations[0].Source.Name
 	}
 	if filename == "" {
 		filename = "input"

--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -11,14 +11,11 @@ import (
 
 // Error is the standard graphql error type described in https://spec.graphql.org/draft/#sec-Errors
 type Error struct {
-	Err       error      `json:"-"`
-	Message   string     `json:"message"`
-	Path      ast.Path   `json:"path,omitempty"`
-	Locations []Location `json:"locations,omitempty"`
-	// LocationSources aligns source documents with Locations by index. An entry
-	// may be nil when the corresponding location has no source document.
-	// Keeping the sources on Error preserves Location's two-field literal shape.
-	LocationSources []*ast.Source  `json:"-"`
+	Err             error      `json:"-"`
+	Message         string     `json:"message"`
+	Path            ast.Path   `json:"path,omitempty"`
+	Locations       []Location `json:"locations,omitempty"`
+	sourceLocations []SourceLocation
 	Extensions      map[string]any `json:"extensions,omitempty"`
 	Rule            string         `json:"-"`
 }
@@ -39,6 +36,34 @@ type Location struct {
 	Column int `json:"column,omitempty"`
 }
 
+// SourceLocation identifies a location and its source document. Source is nil
+// when the location has no source document.
+type SourceLocation struct {
+	Location Location
+	Source   *ast.Source
+}
+
+// AddLocation appends a location to the GraphQL response and its source-aware
+// representation.
+func (err *Error) AddLocation(location Location, source *ast.Source) {
+	err.Locations = append(err.Locations, location)
+	err.sourceLocations = append(err.sourceLocations, SourceLocation{
+		Location: location,
+		Source:   source,
+	})
+}
+
+// SourceLocations returns a shallow copy of the source-aware locations in
+// validation order.
+func (err *Error) SourceLocations() []SourceLocation {
+	if err == nil {
+		return nil
+	}
+	locations := make([]SourceLocation, len(err.sourceLocations))
+	copy(locations, err.sourceLocations)
+	return locations
+}
+
 type List []*Error
 
 func (err *Error) Error() string {
@@ -47,9 +72,9 @@ func (err *Error) Error() string {
 		return ""
 	}
 	filename := ""
-	hasPrimarySource := len(err.LocationSources) > 0 && err.LocationSources[0] != nil
+	hasPrimarySource := len(err.sourceLocations) > 0 && err.sourceLocations[0].Source != nil
 	if hasPrimarySource {
-		filename = err.LocationSources[0].Name
+		filename = err.sourceLocations[0].Source.Name
 	} else {
 		filename, _ = err.Extensions["file"].(string)
 	}
@@ -184,27 +209,15 @@ func ErrorPosf(pos *ast.Position, message string, args ...any) *Error {
 			args...,
 		)
 	}
-	err := ErrorLocf(
-		pos.Src.Name,
-		pos.Line,
-		pos.Column,
-		message,
-		args...,
-	)
-	err.LocationSources = []*ast.Source{pos.Src}
+	err := &Error{Message: fmt.Sprintf(message, args...)}
+	err.SetFile(pos.Src.Name)
+	err.AddLocation(Location{Line: pos.Line, Column: pos.Column}, pos.Src)
 	return err
 }
 
 func ErrorLocf(file string, line, col int, message string, args ...any) *Error {
-	var extensions map[string]any
-	if file != "" {
-		extensions = map[string]any{"file": file}
-	}
-	return &Error{
-		Message:    fmt.Sprintf(message, args...),
-		Extensions: extensions,
-		Locations: []Location{
-			{Line: line, Column: col},
-		},
-	}
+	err := &Error{Message: fmt.Sprintf(message, args...)}
+	err.SetFile(file)
+	err.AddLocation(Location{Line: line, Column: col}, nil)
+	return err
 }

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -55,6 +55,23 @@ func TestErrorFormatting(t *testing.T) {
 
 		require.Equal(t, `input: a[1].b kabloom`, err.Error())
 	})
+
+	t.Run("with multiple sources", func(t *testing.T) {
+		err := &Error{
+			Message: "kabloom",
+			Locations: []Location{
+				{Line: 1, Column: 2},
+				{Line: 3, Column: 4},
+			},
+			LocationSources: []*ast.Source{
+				{Name: "first.graphql"},
+				{Name: "second.graphql"},
+			},
+			Extensions: map[string]any{"file": "second.graphql"},
+		}
+
+		require.Equal(t, `first.graphql:1:2: kabloom`, err.Error())
+	})
 }
 
 func TestErrorPosition(t *testing.T) {
@@ -75,19 +92,19 @@ func TestErrorPosition(t *testing.T) {
 		err := ErrorPosf(position, "kabloom")
 
 		require.Len(t, err.Locations, 1)
-		require.Same(t, source, err.Locations[0].Source)
+		require.Len(t, err.LocationSources, 1)
+		require.Same(t, source, err.LocationSources[0])
 	})
 }
 
-func TestLocationSourceIsNotSerialized(t *testing.T) {
+func TestLocationSourcesAreNotSerialized(t *testing.T) {
 	source := &ast.Source{Name: "query.graphql", Input: "query Q { field }"}
 	err := &Error{
 		Message: "kabloom",
 		Locations: []Location{{
-			Line:   1,
-			Column: 11,
-			Source: source,
+			Line: 1, Column: 11,
 		}},
+		LocationSources: []*ast.Source{source},
 	}
 
 	encoded, errEncoding := json.Marshal(err)

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -88,6 +88,17 @@ func TestErrorFormatting(t *testing.T) {
 
 		require.Equal(t, `input:1:2: kabloom`, err.Error())
 	})
+
+	t.Run("with overridden single-location file", func(t *testing.T) {
+		err := ErrorPosf(&ast.Position{
+			Src:    &ast.Source{Name: "query.graphql"},
+			Line:   1,
+			Column: 2,
+		}, "kabloom")
+		err.SetFile("override.graphql")
+
+		require.Equal(t, `override.graphql:1:2: kabloom`, err.Error())
+	})
 }
 
 func TestErrorPosition(t *testing.T) {
@@ -166,6 +177,22 @@ func TestAddLocationHydratesJSONLocations(t *testing.T) {
 	}, err.SourceLocations())
 }
 
+func TestUnmarshalJSONClearsSourceLocations(t *testing.T) {
+	err := &Error{Message: "first"}
+	err.AddLocation(
+		Location{Line: 1, Column: 2},
+		&ast.Source{Name: "first.graphql"},
+	)
+
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"message":"second","locations":[{"line":1,"column":2}]}`),
+		err,
+	))
+
+	require.Empty(t, err.SourceLocations())
+	require.Equal(t, `input:1:2: second`, err.Error())
+}
+
 func TestSourceLocationsRejectsIndependentLocationChanges(t *testing.T) {
 	t.Run("replacement", func(t *testing.T) {
 		err := &Error{}
@@ -203,6 +230,18 @@ func TestSourceLocationsRejectsIndependentLocationChanges(t *testing.T) {
 			func() { err.SourceLocations() },
 		)
 	})
+}
+
+func TestErrorFormattingToleratesIndependentLocationChanges(t *testing.T) {
+	err := &Error{
+		Message:    "kabloom",
+		Extensions: map[string]any{"file": "second.graphql"},
+	}
+	err.AddLocation(Location{Line: 1, Column: 2}, &ast.Source{Name: "first.graphql"})
+	err.AddLocation(Location{Line: 3, Column: 4}, &ast.Source{Name: "second.graphql"})
+	err.Locations[0] = Location{Line: 5, Column: 6}
+
+	require.Equal(t, `second.graphql:5:6: kabloom`, err.Error())
 }
 
 func TestList_As(t *testing.T) {

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -58,34 +58,22 @@ func TestErrorFormatting(t *testing.T) {
 
 	t.Run("with multiple sources", func(t *testing.T) {
 		err := &Error{
-			Message: "kabloom",
-			Locations: []Location{
-				{Line: 1, Column: 2},
-				{Line: 3, Column: 4},
-			},
-			LocationSources: []*ast.Source{
-				{Name: "first.graphql"},
-				{Name: "second.graphql"},
-			},
+			Message:    "kabloom",
 			Extensions: map[string]any{"file": "second.graphql"},
 		}
+		err.AddLocation(Location{Line: 1, Column: 2}, &ast.Source{Name: "first.graphql"})
+		err.AddLocation(Location{Line: 3, Column: 4}, &ast.Source{Name: "second.graphql"})
 
 		require.Equal(t, `first.graphql:1:2: kabloom`, err.Error())
 	})
 
 	t.Run("with unnamed primary source", func(t *testing.T) {
 		err := &Error{
-			Message: "kabloom",
-			Locations: []Location{
-				{Line: 1, Column: 2},
-				{Line: 3, Column: 4},
-			},
-			LocationSources: []*ast.Source{
-				{},
-				{Name: "second.graphql"},
-			},
+			Message:    "kabloom",
 			Extensions: map[string]any{"file": "second.graphql"},
 		}
+		err.AddLocation(Location{Line: 1, Column: 2}, &ast.Source{})
+		err.AddLocation(Location{Line: 3, Column: 4}, &ast.Source{Name: "second.graphql"})
 
 		require.Equal(t, `input:1:2: kabloom`, err.Error())
 	})
@@ -109,24 +97,34 @@ func TestErrorPosition(t *testing.T) {
 		err := ErrorPosf(position, "kabloom")
 
 		require.Len(t, err.Locations, 1)
-		require.Len(t, err.LocationSources, 1)
-		require.Same(t, source, err.LocationSources[0])
+		sourceLocations := err.SourceLocations()
+		require.Len(t, sourceLocations, 1)
+		require.Equal(t, Location{Line: 1, Column: 11}, sourceLocations[0].Location)
+		require.Same(t, source, sourceLocations[0].Source)
 	})
 }
 
-func TestLocationSourcesAreNotSerialized(t *testing.T) {
+func TestSourceLocationsAreNotSerialized(t *testing.T) {
 	source := &ast.Source{Name: "query.graphql", Input: "query Q { field }"}
-	err := &Error{
-		Message: "kabloom",
-		Locations: []Location{{
-			Line: 1, Column: 11,
-		}},
-		LocationSources: []*ast.Source{source},
-	}
+	err := &Error{Message: "kabloom"}
+	err.AddLocation(Location{Line: 1, Column: 11}, source)
 
 	encoded, errEncoding := json.Marshal(err)
 	require.NoError(t, errEncoding)
 	require.JSONEq(t, `{"message":"kabloom","locations":[{"line":1,"column":11}]}`, string(encoded))
+}
+
+func TestSourceLocationsReturnsCopy(t *testing.T) {
+	source := &ast.Source{Name: "query.graphql"}
+	err := &Error{}
+	err.AddLocation(Location{Line: 1, Column: 2}, source)
+
+	locations := err.SourceLocations()
+	locations[0].Location.Line = 99
+	locations[0].Source = nil
+
+	require.Equal(t, Location{Line: 1, Column: 2}, err.SourceLocations()[0].Location)
+	require.Same(t, source, err.SourceLocations()[0].Source)
 }
 
 func TestList_As(t *testing.T) {

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -77,6 +77,17 @@ func TestErrorFormatting(t *testing.T) {
 
 		require.Equal(t, `input:1:2: kabloom`, err.Error())
 	})
+
+	t.Run("with source-less primary location", func(t *testing.T) {
+		err := &Error{
+			Message:    "kabloom",
+			Extensions: map[string]any{"file": "second.graphql"},
+		}
+		err.AddLocation(Location{Line: 1, Column: 2}, nil)
+		err.AddLocation(Location{Line: 3, Column: 4}, &ast.Source{Name: "second.graphql"})
+
+		require.Equal(t, `input:1:2: kabloom`, err.Error())
+	})
 }
 
 func TestErrorPosition(t *testing.T) {
@@ -125,6 +136,73 @@ func TestSourceLocationsReturnsCopy(t *testing.T) {
 
 	require.Equal(t, Location{Line: 1, Column: 2}, err.SourceLocations()[0].Location)
 	require.Same(t, source, err.SourceLocations()[0].Source)
+}
+
+func TestAddLocationHydratesExistingLocations(t *testing.T) {
+	source := &ast.Source{Name: "second.graphql"}
+	err := &Error{Locations: []Location{{Line: 1, Column: 2}}}
+
+	err.AddLocation(Location{Line: 3, Column: 4}, source)
+
+	require.Equal(t, []SourceLocation{
+		{Location: Location{Line: 1, Column: 2}},
+		{Location: Location{Line: 3, Column: 4}, Source: source},
+	}, err.SourceLocations())
+}
+
+func TestAddLocationHydratesJSONLocations(t *testing.T) {
+	source := &ast.Source{Name: "second.graphql"}
+	var err Error
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"message":"kabloom","locations":[{"line":1,"column":2}]}`),
+		&err,
+	))
+
+	err.AddLocation(Location{Line: 3, Column: 4}, source)
+
+	require.Equal(t, []SourceLocation{
+		{Location: Location{Line: 1, Column: 2}},
+		{Location: Location{Line: 3, Column: 4}, Source: source},
+	}, err.SourceLocations())
+}
+
+func TestSourceLocationsRejectsIndependentLocationChanges(t *testing.T) {
+	t.Run("replacement", func(t *testing.T) {
+		err := &Error{}
+		err.AddLocation(Location{Line: 1, Column: 2}, &ast.Source{Name: "query.graphql"})
+		err.Locations[0] = Location{Line: 3, Column: 4}
+
+		require.PanicsWithValue(
+			t,
+			"gqlerror: location 0 changed independently of its source",
+			func() { err.SourceLocations() },
+		)
+	})
+
+	t.Run("reordering", func(t *testing.T) {
+		err := &Error{}
+		err.AddLocation(Location{Line: 1, Column: 2}, &ast.Source{Name: "first.graphql"})
+		err.AddLocation(Location{Line: 3, Column: 4}, &ast.Source{Name: "second.graphql"})
+		err.Locations[0], err.Locations[1] = err.Locations[1], err.Locations[0]
+
+		require.PanicsWithValue(
+			t,
+			"gqlerror: location 0 changed independently of its source",
+			func() { err.SourceLocations() },
+		)
+	})
+
+	t.Run("clearing", func(t *testing.T) {
+		err := &Error{}
+		err.AddLocation(Location{Line: 1, Column: 2}, &ast.Source{Name: "query.graphql"})
+		err.Locations = nil
+
+		require.PanicsWithValue(
+			t,
+			"gqlerror: location count 0 does not match source location count 1",
+			func() { err.SourceLocations() },
+		)
+	})
 }
 
 func TestList_As(t *testing.T) {

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -72,6 +72,23 @@ func TestErrorFormatting(t *testing.T) {
 
 		require.Equal(t, `first.graphql:1:2: kabloom`, err.Error())
 	})
+
+	t.Run("with unnamed primary source", func(t *testing.T) {
+		err := &Error{
+			Message: "kabloom",
+			Locations: []Location{
+				{Line: 1, Column: 2},
+				{Line: 3, Column: 4},
+			},
+			LocationSources: []*ast.Source{
+				{},
+				{Name: "second.graphql"},
+			},
+			Extensions: map[string]any{"file": "second.graphql"},
+		}
+
+		require.Equal(t, `input:1:2: kabloom`, err.Error())
+	})
 }
 
 func TestErrorPosition(t *testing.T) {

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -1,6 +1,7 @@
 package gqlerror
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -66,6 +67,32 @@ func TestErrorPosition(t *testing.T) {
 		require.Nil(t, err.Extensions["file"])
 		require.Nil(t, errNilPosition.Extensions["file"])
 	})
+
+	t.Run("retains source", func(t *testing.T) {
+		source := &ast.Source{Name: "query.graphql", Input: "query Q { field }"}
+		position := &ast.Position{Line: 1, Column: 11, Src: source}
+
+		err := ErrorPosf(position, "kabloom")
+
+		require.Len(t, err.Locations, 1)
+		require.Same(t, source, err.Locations[0].Source)
+	})
+}
+
+func TestLocationSourceIsNotSerialized(t *testing.T) {
+	source := &ast.Source{Name: "query.graphql", Input: "query Q { field }"}
+	err := &Error{
+		Message: "kabloom",
+		Locations: []Location{{
+			Line:   1,
+			Column: 11,
+			Source: source,
+		}},
+	}
+
+	encoded, errEncoding := json.Marshal(err)
+	require.NoError(t, errEncoding)
+	require.JSONEq(t, `{"message":"kabloom","locations":[{"line":1,"column":11}]}`, string(encoded))
 }
 
 func TestList_As(t *testing.T) {

--- a/validator/core/helpers.go
+++ b/validator/core/helpers.go
@@ -31,9 +31,9 @@ func At(position *ast.Position) ErrorOption {
 		err.Locations = append(err.Locations, gqlerror.Location{
 			Line:   position.Line,
 			Column: position.Column,
-			Source: position.Src,
 		})
-		if position.Src.Name != "" {
+		err.LocationSources = append(err.LocationSources, position.Src)
+		if len(err.Locations) == 1 && position.Src.Name != "" {
 			err.SetFile(position.Src.Name)
 		}
 	}

--- a/validator/core/helpers.go
+++ b/validator/core/helpers.go
@@ -28,11 +28,10 @@ func At(position *ast.Position) ErrorOption {
 		if position == nil {
 			return
 		}
-		err.Locations = append(err.Locations, gqlerror.Location{
+		err.AddLocation(gqlerror.Location{
 			Line:   position.Line,
 			Column: position.Column,
-		})
-		err.LocationSources = append(err.LocationSources, position.Src)
+		}, position.Src)
 		if position.Src.Name != "" {
 			err.SetFile(position.Src.Name)
 		}

--- a/validator/core/helpers.go
+++ b/validator/core/helpers.go
@@ -19,6 +19,10 @@ func Message(msg string, args ...any) ErrorOption {
 	}
 }
 
+// At appends a source position in the order the validation rule supplies it.
+// The first position is the primary location. Keeping option order preserves
+// the order of GraphQL validation nodes and makes multi-location diagnostics
+// deterministic without sorting locations from different source documents.
 func At(position *ast.Position) ErrorOption {
 	return func(err *gqlerror.Error) {
 		if position == nil {
@@ -27,6 +31,7 @@ func At(position *ast.Position) ErrorOption {
 		err.Locations = append(err.Locations, gqlerror.Location{
 			Line:   position.Line,
 			Column: position.Column,
+			Source: position.Src,
 		})
 		if position.Src.Name != "" {
 			err.SetFile(position.Src.Name)

--- a/validator/core/helpers.go
+++ b/validator/core/helpers.go
@@ -33,7 +33,7 @@ func At(position *ast.Position) ErrorOption {
 			Column: position.Column,
 		})
 		err.LocationSources = append(err.LocationSources, position.Src)
-		if len(err.Locations) == 1 && position.Src.Name != "" {
+		if position.Src.Name != "" {
 			err.SetFile(position.Src.Name)
 		}
 	}

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"github.com/vektah/gqlparser/v2/parser"
 	"github.com/vektah/gqlparser/v2/validator"
 	"github.com/vektah/gqlparser/v2/validator/rules"
@@ -42,6 +43,78 @@ extend type Query {
 
 	require.Nil(t, validator.Validate(s, q))
 	require.Nil(t, validator.ValidateWithRules(s, q, nil))
+}
+
+func TestVariablesInAllowedPositionRetainsSourcesForMultipleLocations(t *testing.T) {
+	s := gqlparser.MustLoadSchema(&ast.Source{
+		Name: "schema.graphqls",
+		Input: `
+input Filter @oneOf {
+  byID: ID
+}
+
+type Query {
+  search(filter: Filter): String
+}
+`,
+	})
+
+	querySource := &ast.Source{
+		Name:  "queries/Search.graphql",
+		Input: "query Search($id: ID) { ...SearchFields }",
+	}
+	fragmentSource := &ast.Source{
+		Name:  "fragments/SearchFields.graphql",
+		Input: "fragment SearchFields on Query { search(filter: {byID: $id}) }",
+	}
+	query, err := parser.ParseQuery(querySource)
+	require.NoError(t, err)
+	fragment, err := parser.ParseQuery(fragmentSource)
+	require.NoError(t, err)
+
+	doc := &ast.QueryDocument{
+		Operations: query.Operations,
+		Fragments:  fragment.Fragments,
+	}
+	errs := validator.Validate(s, doc)
+
+	var found *gqlerror.Error
+	for _, err := range errs {
+		if err.Rule == "VariablesInAllowedPosition" {
+			found = err
+			break
+		}
+	}
+	require.NotNil(t, found, "expected a VariablesInAllowedPosition error, got %v", errs)
+	require.Len(t, found.Locations, 2)
+	require.Same(t, querySource, found.Locations[0].Source)
+	require.Same(t, fragmentSource, found.Locations[1].Source)
+	require.Equal(t, 1, found.Locations[0].Line)
+	require.Equal(t, 1, found.Locations[1].Line)
+}
+
+func TestSingleLocationValidationRetainsSource(t *testing.T) {
+	s := gqlparser.MustLoadSchema(&ast.Source{
+		Name:  "schema.graphqls",
+		Input: "type Query { search: String }",
+	})
+	source := &ast.Source{
+		Name:  "queries/Search.graphql",
+		Input: "query Search { missing }",
+	}
+	query, err := parser.ParseQuery(source)
+	require.NoError(t, err)
+
+	var found *gqlerror.Error
+	for _, err := range validator.Validate(s, query) {
+		if err.Rule == "FieldsOnCorrectType" {
+			found = err
+			break
+		}
+	}
+	require.NotNil(t, found)
+	require.Len(t, found.Locations, 1)
+	require.Same(t, source, found.Locations[0].Source)
 }
 
 func TestValidationRulesAreIndependent(t *testing.T) {

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -87,10 +87,13 @@ type Query {
 	}
 	require.NotNil(t, found, "expected a VariablesInAllowedPosition error, got %v", errs)
 	require.Len(t, found.Locations, 2)
-	require.Same(t, querySource, found.Locations[0].Source)
-	require.Same(t, fragmentSource, found.Locations[1].Source)
+	require.Len(t, found.LocationSources, 2)
+	require.Same(t, querySource, found.LocationSources[0])
+	require.Same(t, fragmentSource, found.LocationSources[1])
 	require.Equal(t, 1, found.Locations[0].Line)
 	require.Equal(t, 1, found.Locations[1].Line)
+	require.Equal(t, querySource.Name, found.Extensions["file"])
+	require.Equal(t, "queries/Search.graphql:1:14: "+found.Message, found.Error())
 }
 
 func TestSingleLocationValidationRetainsSource(t *testing.T) {
@@ -114,7 +117,8 @@ func TestSingleLocationValidationRetainsSource(t *testing.T) {
 	}
 	require.NotNil(t, found)
 	require.Len(t, found.Locations, 1)
-	require.Same(t, source, found.Locations[0].Source)
+	require.Len(t, found.LocationSources, 1)
+	require.Same(t, source, found.LocationSources[0])
 }
 
 func TestValidationRulesAreIndependent(t *testing.T) {

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -1,6 +1,7 @@
 package validator_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -92,8 +93,21 @@ type Query {
 	require.Same(t, fragmentSource, found.LocationSources[1])
 	require.Equal(t, 1, found.Locations[0].Line)
 	require.Equal(t, 1, found.Locations[1].Line)
-	require.Equal(t, querySource.Name, found.Extensions["file"])
+	require.Equal(t, 14, found.Locations[0].Column)
+	require.Equal(t, 56, found.Locations[1].Column)
+	require.Equal(t, fragmentSource.Name, found.Extensions["file"])
 	require.Equal(t, "queries/Search.graphql:1:14: "+found.Message, found.Error())
+
+	encoded, marshalErr := json.Marshal(found)
+	require.NoError(t, marshalErr)
+	require.JSONEq(t, `{
+		"message": "Variable \"$id\" is of type \"ID\" but must be non-nullable to be used for OneOf Input Object \"Filter\".",
+		"locations": [
+			{"line": 1, "column": 14},
+			{"line": 1, "column": 56}
+		],
+		"extensions": {"file": "fragments/SearchFields.graphql"}
+	}`, string(encoded))
 }
 
 func TestSingleLocationValidationRetainsSource(t *testing.T) {

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -88,9 +88,12 @@ type Query {
 	}
 	require.NotNil(t, found, "expected a VariablesInAllowedPosition error, got %v", errs)
 	require.Len(t, found.Locations, 2)
-	require.Len(t, found.LocationSources, 2)
-	require.Same(t, querySource, found.LocationSources[0])
-	require.Same(t, fragmentSource, found.LocationSources[1])
+	sourceLocations := found.SourceLocations()
+	require.Len(t, sourceLocations, 2)
+	require.Equal(t, found.Locations[0], sourceLocations[0].Location)
+	require.Equal(t, found.Locations[1], sourceLocations[1].Location)
+	require.Same(t, querySource, sourceLocations[0].Source)
+	require.Same(t, fragmentSource, sourceLocations[1].Source)
 	require.Equal(t, 1, found.Locations[0].Line)
 	require.Equal(t, 1, found.Locations[1].Line)
 	require.Equal(t, 14, found.Locations[0].Column)
@@ -131,8 +134,10 @@ func TestSingleLocationValidationRetainsSource(t *testing.T) {
 	}
 	require.NotNil(t, found)
 	require.Len(t, found.Locations, 1)
-	require.Len(t, found.LocationSources, 1)
-	require.Same(t, source, found.LocationSources[0])
+	sourceLocations := found.SourceLocations()
+	require.Len(t, sourceLocations, 1)
+	require.Equal(t, found.Locations[0], sourceLocations[0].Location)
+	require.Same(t, source, sourceLocations[0].Source)
 }
 
 func TestValidationRulesAreIndependent(t *testing.T) {


### PR DESCRIPTION
## Why

Validation errors can refer to multiple source positions. gqlparser currently stores their coordinates in `Locations`, but `extensions.file` is one error-level filename. Each `At` call overwrites that filename, so it identifies the final source rather than every location's source.

`VariablesInAllowedPosition` can refer to both a variable declaration and its use. Those nodes may be in separate query and fragment files. Callers cannot currently associate each coordinate with the correct file.

## How

Add `SourceLocation`, which keeps each `Location` and `ast.Source` together in validation-rule order. Add `Error.AddLocation` and `Error.SourceLocations` for producing and consuming these records.

Keep `Location`, GraphQL JSON, single-location formatting, and `SetFile` behavior unchanged. Keyed `Error` literals remain compatible. External unkeyed `Error` literals must become keyed because the implementation adds private state.

Add coverage for cross-file validation, single-location errors, JSON decoding, source ordering, and public `Locations` mutation.

I have:
 - [x] Added tests covering the bug / feature
 - [x] Updated any relevant documentation
