### PR TITLE
validator: add opt-in source-aware validation errors

### DIFF
--- a/gqlerror/compatibility_test.go
+++ b/gqlerror/compatibility_test.go
@@ -1,0 +1,35 @@
+package gqlerror_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+func TestLocationSupportsUnkeyedLiteral(t *testing.T) {
+	location := gqlerror.Location{1, 2}
+
+	require.Equal(t, 1, location.Line)
+	require.Equal(t, 2, location.Column)
+}
+
+func TestErrorSupportsUnkeyedLiteral(t *testing.T) {
+	err := gqlerror.Error{nil, "kabloom", nil, nil, nil, ""}
+
+	require.Equal(t, "kabloom", err.Message)
+}
+
+func TestErrorWithSourcesIsAvailableOutsidePackage(t *testing.T) {
+	source := &ast.Source{Name: "query.graphql"}
+	err := gqlerror.NewErrorWithSources(
+		&gqlerror.Error{Locations: []gqlerror.Location{{Line: 1, Column: 2}}},
+		[]gqlerror.SourceLocation{{Line: 1, Column: 2, Source: source}},
+	)
+
+	require.Len(t, err.Locations, 1)
+	require.Same(t, source, err.Locations[0].Source)
+	require.Equal(t, gqlerror.SourceLocation{Line: 1, Column: 2, Source: source}, err.Locations[0])
+}

--- a/gqlerror/error.go
+++ b/gqlerror/error.go
@@ -1,6 +1,7 @@
 package gqlerror
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -33,6 +34,202 @@ func (err *Error) SetFile(file string) {
 type Location struct {
 	Line   int `json:"line,omitempty"`
 	Column int `json:"column,omitempty"`
+}
+
+// SourceLocation pairs a GraphQL line and column with its source document.
+// Source is nil when the location has no source document.
+type SourceLocation struct {
+	Line   int         `json:"line,omitempty"`
+	Column int         `json:"column,omitempty"`
+	Source *ast.Source `json:"-"`
+}
+
+// ErrorWithSources is the source-aware validation error returned by the
+// opt-in validator API. It retains the standard GraphQL error fields while
+// Locations stores each location together with its source document. Source is
+// omitted from JSON, leaving the standard GraphQL line and column fields.
+type ErrorWithSources struct {
+	Err        error            `json:"-"`
+	Message    string           `json:"message"`
+	Path       ast.Path         `json:"path,omitempty"`
+	Locations  []SourceLocation `json:"locations,omitempty"`
+	Extensions map[string]any   `json:"extensions,omitempty"`
+	Rule       string           `json:"-"`
+
+	legacyLocations bool
+}
+
+// NewErrorWithSources pairs an existing GraphQL error with source-aware
+// locations. The location slice is copied so callers cannot change the error's
+// source associations by mutating their input slice.
+func NewErrorWithSources(err *Error, locations []SourceLocation) *ErrorWithSources {
+	if err == nil {
+		return nil
+	}
+	legacyLocations := locations == nil
+	if len(locations) > 0 && len(err.Locations) > 0 {
+		if len(locations) != len(err.Locations) {
+			panic(fmt.Sprintf(
+				"gqlerror: source location count %d does not match location count %d",
+				len(locations),
+				len(err.Locations),
+			))
+		}
+		for i, location := range err.Locations {
+			if locations[i].Line != location.Line || locations[i].Column != location.Column {
+				panic(fmt.Sprintf(
+					"gqlerror: source location %d does not match location coordinates",
+					i,
+				))
+			}
+		}
+	}
+	if len(locations) == 0 && len(err.Locations) > 0 {
+		locations = make([]SourceLocation, len(err.Locations))
+		for i, location := range err.Locations {
+			locations[i] = SourceLocation{
+				Line:   location.Line,
+				Column: location.Column,
+			}
+		}
+	}
+	return &ErrorWithSources{
+		Err:             err.Err,
+		Message:         err.Message,
+		Path:            err.Path,
+		Locations:       append([]SourceLocation(nil), locations...),
+		Extensions:      err.Extensions,
+		Rule:            err.Rule,
+		legacyLocations: legacyLocations,
+	}
+}
+
+// UnmarshalJSON discards source documents because GraphQL error JSON does not
+// encode them.
+func (err *ErrorWithSources) UnmarshalJSON(data []byte) error {
+	type errorWithoutMethods ErrorWithSources
+	err.Locations = nil
+	err.legacyLocations = true
+	return json.Unmarshal(data, (*errorWithoutMethods)(err))
+}
+
+func (err *ErrorWithSources) Error() string {
+	if err == nil {
+		return ""
+	}
+	locations := make([]Location, len(err.Locations))
+	for i, sourceLocation := range err.Locations {
+		locations[i] = Location{
+			Line:   sourceLocation.Line,
+			Column: sourceLocation.Column,
+		}
+	}
+	base := &Error{
+		Err:        err.Err,
+		Message:    err.Message,
+		Path:       err.Path,
+		Locations:  locations,
+		Extensions: cloneExtensions(err.Extensions),
+		Rule:       err.Rule,
+	}
+	if base.Extensions == nil {
+		base.Extensions = map[string]any{}
+	}
+	filename, _ := base.Extensions["file"].(string)
+	if len(err.Locations) == 1 {
+		if filename == "" {
+			if source := err.Locations[0].Source; source != nil && source.Name != "" {
+				filename = source.Name
+			}
+		}
+	} else if len(err.Locations) > 1 {
+		if source := err.Locations[0].Source; source != nil {
+			filename = source.Name
+		} else if !err.legacyLocations {
+			filename = ""
+		}
+	}
+	if filename != "" {
+		base.Extensions["file"] = filename
+	} else {
+		delete(base.Extensions, "file")
+	}
+	return base.Error()
+}
+
+func cloneExtensions(extensions map[string]any) map[string]any {
+	if extensions == nil {
+		return nil
+	}
+	clone := make(map[string]any, len(extensions))
+	for key, value := range extensions {
+		clone[key] = value
+	}
+	return clone
+}
+
+func (err *ErrorWithSources) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	return err.Err
+}
+
+func (err *ErrorWithSources) AsError() error {
+	if err == nil {
+		return nil
+	}
+	return err
+}
+
+// SourceLocations returns a shallow copy of the source-aware locations in
+// validation order.
+func (err *ErrorWithSources) SourceLocations() []SourceLocation {
+	if err == nil || len(err.Locations) == 0 {
+		return nil
+	}
+	locations := make([]SourceLocation, len(err.Locations))
+	copy(locations, err.Locations)
+	return locations
+}
+
+// SourceList is the result type returned by the opt-in source-aware validator
+// APIs.
+type SourceList []*ErrorWithSources
+
+func (errs SourceList) Error() string {
+	var buf strings.Builder
+	for _, err := range errs {
+		buf.WriteString(err.Error())
+		buf.WriteByte('\n')
+	}
+	return buf.String()
+}
+
+func (errs SourceList) Is(target error) bool {
+	for _, err := range errs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (errs SourceList) As(target any) bool {
+	for _, err := range errs {
+		if errors.As(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (errs SourceList) Unwrap() []error {
+	l := make([]error, len(errs))
+	for i, err := range errs {
+		l[i] = err
+	}
+	return l
 }
 
 type List []*Error

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -186,6 +186,23 @@ func TestNewErrorWithSourcesCopiesInputLocations(t *testing.T) {
 	require.Equal(t, SourceLocation{Line: 1, Column: 2, Source: source}, err.Locations[0])
 }
 
+func TestNewErrorWithSourcesCopiesLegacyLocationsWithoutSources(t *testing.T) {
+	err := NewErrorWithSources(
+		&Error{
+			Message:    "kabloom",
+			Locations:  []Location{{Line: 1, Column: 2}, {Line: 3, Column: 4}},
+			Extensions: map[string]any{"file": "legacy.graphql"},
+		},
+		nil,
+	)
+
+	require.Equal(t, []SourceLocation{
+		{Line: 1, Column: 2},
+		{Line: 3, Column: 4},
+	}, err.Locations)
+	require.Equal(t, `legacy.graphql:1:2: kabloom`, err.Error())
+}
+
 func TestNewErrorWithSourcesRejectsMismatchedLocations(t *testing.T) {
 	require.PanicsWithValue(
 		t,

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -1,6 +1,7 @@
 package gqlerror
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -54,6 +55,27 @@ func TestErrorFormatting(t *testing.T) {
 
 		require.Equal(t, `input: a[1].b kabloom`, err.Error())
 	})
+
+	t.Run("with legacy multi-location file extension", func(t *testing.T) {
+		err := &Error{
+			Message:    "kabloom",
+			Locations:  []Location{{Line: 1, Column: 2}, {Line: 3, Column: 4}},
+			Extensions: map[string]any{"file": "legacy.graphql"},
+		}
+
+		require.Equal(t, `legacy.graphql:1:2: kabloom`, err.Error())
+	})
+
+	t.Run("with overridden single-location file", func(t *testing.T) {
+		err := ErrorPosf(&ast.Position{
+			Src:    &ast.Source{Name: "query.graphql"},
+			Line:   1,
+			Column: 2,
+		}, "kabloom")
+		err.SetFile("override.graphql")
+
+		require.Equal(t, `override.graphql:1:2: kabloom`, err.Error())
+	})
 }
 
 func TestErrorPosition(t *testing.T) {
@@ -66,6 +88,146 @@ func TestErrorPosition(t *testing.T) {
 		require.Nil(t, err.Extensions["file"])
 		require.Nil(t, errNilPosition.Extensions["file"])
 	})
+
+}
+
+func TestErrorWithSourcesAreNotSerialized(t *testing.T) {
+	source := &ast.Source{Name: "query.graphql", Input: "query Q { field }"}
+	err := NewErrorWithSources(
+		&Error{
+			Message:   "kabloom",
+			Locations: []Location{{Line: 1, Column: 11}},
+		},
+		[]SourceLocation{{Line: 1, Column: 11, Source: source}},
+	)
+
+	encoded, errEncoding := json.Marshal(err)
+	require.NoError(t, errEncoding)
+	require.JSONEq(t, `{"message":"kabloom","locations":[{"line":1,"column":11}]}`, string(encoded))
+}
+
+func TestErrorWithSourcesUnmarshalClearsSources(t *testing.T) {
+	err := NewErrorWithSources(
+		&Error{Message: "first", Locations: []Location{{Line: 1, Column: 2}}},
+		[]SourceLocation{{Line: 1, Column: 2, Source: &ast.Source{Name: "first.graphql"}}},
+	)
+
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"message":"second","locations":[{"line":3,"column":4}]}`),
+		err,
+	))
+
+	require.Equal(t, "second", err.Message)
+	require.Equal(t, []SourceLocation{{Line: 3, Column: 4}}, err.Locations)
+	require.Equal(t, err.Locations, err.SourceLocations())
+	require.Nil(t, err.Locations[0].Source)
+}
+
+func TestErrorWithSourcesFormatsDirectCanonicalLocations(t *testing.T) {
+	err := &ErrorWithSources{
+		Message: "kabloom",
+		Locations: []SourceLocation{
+			{Line: 1, Column: 2, Source: &ast.Source{Name: "first.graphql"}},
+			{Line: 3, Column: 4, Source: &ast.Source{Name: "second.graphql"}},
+		},
+	}
+
+	require.Equal(t, `first.graphql:1:2: kabloom`, err.Error())
+}
+
+func TestErrorWithSourcesFormatsDirectSingleLocation(t *testing.T) {
+	err := &ErrorWithSources{
+		Message:   "kabloom",
+		Locations: []SourceLocation{{Line: 1, Column: 2, Source: &ast.Source{Name: "query.graphql"}}},
+	}
+
+	require.Equal(t, `query.graphql:1:2: kabloom`, err.Error())
+}
+
+func TestErrorWithSourcesPreservesDirectMissingPrimarySource(t *testing.T) {
+	err := &ErrorWithSources{
+		Message:    "kabloom",
+		Extensions: map[string]any{"file": "second.graphql"},
+		Locations: []SourceLocation{
+			{Line: 1, Column: 2},
+			{Line: 3, Column: 4, Source: &ast.Source{Name: "second.graphql"}},
+		},
+	}
+
+	require.Equal(t, `input:1:2: kabloom`, err.Error())
+}
+
+func TestErrorWithSourcesReturnsDerivedCopy(t *testing.T) {
+	source := &ast.Source{Name: "query.graphql"}
+	err := NewErrorWithSources(
+		&Error{Locations: []Location{{Line: 1, Column: 2}}},
+		[]SourceLocation{{Line: 1, Column: 2, Source: source}},
+	)
+
+	locations := err.SourceLocations()
+	locations[0].Line = 99
+	locations[0].Source = nil
+
+	require.Equal(t, SourceLocation{Line: 1, Column: 2, Source: source}, err.SourceLocations()[0])
+	require.Same(t, source, err.SourceLocations()[0].Source)
+}
+
+func TestNewErrorWithSourcesCopiesInputLocations(t *testing.T) {
+	source := &ast.Source{Name: "query.graphql"}
+	locations := []SourceLocation{{Line: 1, Column: 2, Source: source}}
+	err := NewErrorWithSources(
+		&Error{Locations: []Location{{Line: 1, Column: 2}}},
+		locations,
+	)
+
+	locations[0].Line = 99
+	locations[0].Source = nil
+
+	require.Equal(t, SourceLocation{Line: 1, Column: 2, Source: source}, err.Locations[0])
+}
+
+func TestNewErrorWithSourcesRejectsMismatchedLocations(t *testing.T) {
+	require.PanicsWithValue(
+		t,
+		"gqlerror: source location count 2 does not match location count 1",
+		func() {
+			NewErrorWithSources(
+				&Error{Locations: []Location{{Line: 1, Column: 2}}},
+				[]SourceLocation{{Line: 1, Column: 2}, {Line: 3, Column: 4}},
+			)
+		},
+	)
+}
+
+func TestNewErrorWithSourcesRejectsMismatchedCoordinates(t *testing.T) {
+	require.PanicsWithValue(
+		t,
+		"gqlerror: source location 0 does not match location coordinates",
+		func() {
+			NewErrorWithSources(
+				&Error{Locations: []Location{{Line: 1, Column: 2}}},
+				[]SourceLocation{{Line: 3, Column: 4}},
+			)
+		},
+	)
+}
+
+func TestSourceListMatchesListErrorBehavior(t *testing.T) {
+	first := &ErrorWithSources{Message: "first"}
+	second := &ErrorWithSources{Err: underlyingError, Message: "second"}
+	errs := SourceList{first, second}
+
+	require.EqualError(t, errs, "input: first\ninput: second\n")
+	require.True(t, errs.Is(underlyingError))
+
+	var found *ErrorWithSources
+	require.True(t, errs.As(&found))
+	require.Same(t, first, found)
+
+	unwrapped := errs.Unwrap()
+	require.Len(t, unwrapped, 2)
+	require.Same(t, first, unwrapped[0])
+	require.Same(t, second, unwrapped[1])
 }
 
 func TestList_As(t *testing.T) {

--- a/gqlerror/error_test.go
+++ b/gqlerror/error_test.go
@@ -88,7 +88,6 @@ func TestErrorPosition(t *testing.T) {
 		require.Nil(t, err.Extensions["file"])
 		require.Nil(t, errNilPosition.Extensions["file"])
 	})
-
 }
 
 func TestErrorWithSourcesAreNotSerialized(t *testing.T) {
@@ -137,8 +136,10 @@ func TestErrorWithSourcesFormatsDirectCanonicalLocations(t *testing.T) {
 
 func TestErrorWithSourcesFormatsDirectSingleLocation(t *testing.T) {
 	err := &ErrorWithSources{
-		Message:   "kabloom",
-		Locations: []SourceLocation{{Line: 1, Column: 2, Source: &ast.Source{Name: "query.graphql"}}},
+		Message: "kabloom",
+		Locations: []SourceLocation{
+			{Line: 1, Column: 2, Source: &ast.Source{Name: "query.graphql"}},
+		},
 	}
 
 	require.Equal(t, `query.graphql:1:2: kabloom`, err.Error())

--- a/validator/core/helpers.go
+++ b/validator/core/helpers.go
@@ -28,6 +28,10 @@ func At(position *ast.Position) ErrorOption {
 			Line:   position.Line,
 			Column: position.Column,
 		})
+		recordSourceLocation(err, gqlerror.Location{
+			Line:   position.Line,
+			Column: position.Column,
+		}, position.Src)
 		if position.Src.Name != "" {
 			err.SetFile(position.Src.Name)
 		}

--- a/validator/core/source_capture.go
+++ b/validator/core/source_capture.go
@@ -1,0 +1,82 @@
+package core
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+type sourceCapture struct {
+	locations []gqlerror.SourceLocation
+}
+
+// sourceCaptures bridges the legacy ErrorOption API: At receives only an
+// *gqlerror.Error and cannot access CaptureSourceLocations' local capture.
+// Entries exist only while source-aware options are being applied.
+var sourceCaptures sync.Map // map[*gqlerror.Error]*sourceCapture
+
+// CaptureSourceLocations applies error options while recording the source
+// documents supplied to At. It returns source-aware locations in the same
+// order as err.Locations.
+// Source-aware validation uses this helper; the regular validation API does
+// not install a capture and keeps its existing behavior.
+func CaptureSourceLocations(err *gqlerror.Error, apply func()) []gqlerror.SourceLocation {
+	if err == nil {
+		panic("gqlparser: cannot capture source locations for a nil error")
+	}
+	capture := &sourceCapture{}
+	sourceCaptures.Store(err, capture)
+	defer sourceCaptures.Delete(err)
+
+	apply()
+	if len(err.Locations) == 0 {
+		if len(capture.locations) > 0 {
+			panic(fmt.Sprintf(
+				"gqlparser: captured source location %d does not match the final error locations",
+				0,
+			))
+		}
+		return nil
+	}
+	locations := make([]gqlerror.SourceLocation, len(err.Locations))
+	for i, location := range err.Locations {
+		locations[i] = gqlerror.SourceLocation{
+			Line:   location.Line,
+			Column: location.Column,
+		}
+	}
+	recorded := 0
+	for i, location := range err.Locations {
+		if recorded == len(capture.locations) {
+			break
+		}
+		captured := capture.locations[recorded]
+		if captured.Line != location.Line || captured.Column != location.Column {
+			continue
+		}
+		locations[i].Source = captured.Source
+		recorded++
+	}
+	if recorded != len(capture.locations) {
+		panic(fmt.Sprintf(
+			"gqlparser: captured source location %d does not match the final error locations",
+			recorded,
+		))
+	}
+	return locations
+}
+
+func recordSourceLocation(err *gqlerror.Error, location gqlerror.Location, source *ast.Source) {
+	value, ok := sourceCaptures.Load(err)
+	if !ok {
+		return
+	}
+	capture := value.(*sourceCapture)
+	capture.locations = append(capture.locations, gqlerror.SourceLocation{
+		Line:   location.Line,
+		Column: location.Column,
+		Source: source,
+	})
+}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -118,6 +118,16 @@ func Validate(schema *Schema, doc *QueryDocument, rules ...Rule) gqlerror.List {
 	return errs
 }
 
+// ValidateWithSources is the source-aware counterpart to Validate. It keeps
+// source documents for every location recorded by the built-in At option while
+// leaving Error and the regular validation API unchanged.
+func ValidateWithSources(schema *Schema, doc *QueryDocument, rules ...Rule) gqlerror.SourceList {
+	if rules == nil {
+		rules = specifiedRules
+	}
+	return validateWithSources(schema, doc, rules)
+}
+
 func ValidateWithRules(
 	schema *Schema,
 	doc *QueryDocument,
@@ -155,6 +165,62 @@ func ValidateWithRules(
 				o(err)
 			}
 			errs = append(errs, err)
+		})
+	}
+
+	Walk(schema, doc, observers)
+	return errs
+}
+
+// ValidateWithRulesWithSources is the source-aware counterpart to
+// ValidateWithRules.
+func ValidateWithRulesWithSources(
+	schema *Schema,
+	doc *QueryDocument,
+	rules *validatorrules.Rules,
+) gqlerror.SourceList {
+	if rules == nil {
+		rules = validatorrules.NewDefaultRules()
+	}
+
+	var currentRules []Rule //nolint:prealloc // would require extra local refs for len
+	for name, ruleFunc := range rules.GetInner() {
+		currentRules = append(currentRules, Rule{Name: name, RuleFunc: ruleFunc})
+		// ensure deterministic order evaluation
+		sort.Sort(core.NameSorter(currentRules))
+	}
+	return validateWithSources(schema, doc, currentRules)
+}
+
+func validateWithSources(schema *Schema, doc *QueryDocument, rules []Rule) gqlerror.SourceList {
+	var errs gqlerror.SourceList
+	if schema == nil {
+		errs = append(errs, gqlerror.NewErrorWithSources(
+			gqlerror.Errorf("cannot validate as Schema is nil"),
+			nil,
+		))
+	}
+	if doc == nil {
+		errs = append(errs, gqlerror.NewErrorWithSources(
+			gqlerror.Errorf("cannot validate as QueryDocument is nil"),
+			nil,
+		))
+	}
+	if len(errs) > 0 {
+		return errs
+	}
+
+	observers := &core.Events{}
+	for i := range rules {
+		rule := rules[i]
+		rule.RuleFunc(observers, func(options ...ErrorOption) {
+			err := &gqlerror.Error{Rule: rule.Name}
+			sources := core.CaptureSourceLocations(err, func() {
+				for _, option := range options {
+					option(err)
+				}
+			})
+			errs = append(errs, gqlerror.NewErrorWithSources(err, sources))
 		})
 	}
 

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -2,6 +2,8 @@ package validator_test
 
 import (
 	"encoding/json"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -178,6 +180,89 @@ func TestValidateWithRulesWithSourcesRetainsOrderedCustomRuleLocations(t *testin
 			{Line: 4, Column: 5, Source: secondSource},
 		}, errs[1].Locations)
 	}
+}
+
+func TestValidateWithRulesWithSourcesIsConcurrent(t *testing.T) {
+	const runs = 16
+	type result struct {
+		source *ast.Source
+		line   int
+		errs   gqlerror.SourceList
+		err    error
+	}
+	results := make(chan result, runs)
+	var wg sync.WaitGroup
+
+	for i := 0; i < runs; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s := gqlparser.MustLoadSchema(&ast.Source{
+				Name:  "schema.graphqls",
+				Input: "type Query { field: String }",
+			})
+			doc, err := parser.ParseQuery(&ast.Source{
+				Name:  "query.graphql",
+				Input: "query Query { field }",
+			})
+			if err != nil {
+				results <- result{err: err}
+				return
+			}
+			source := &ast.Source{Name: fmt.Sprintf("query-%d.graphql", i)}
+			rule := validator.Rule{
+				Name: "ParallelRule",
+				RuleFunc: func(_ *validator.Events, addError validator.AddErrFunc) {
+					addError(
+						validator.Message("parallel"),
+						core.At(&ast.Position{Src: source, Line: i + 1, Column: 2}),
+					)
+				},
+			}
+			results <- result{
+				source: source,
+				line:   i + 1,
+				errs:   validator.ValidateWithRulesWithSources(s, doc, rules.NewRules(rule)),
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+	for result := range results {
+		require.NoError(t, result.err)
+		require.Len(t, result.errs, 1)
+		require.Equal(t, []gqlerror.SourceLocation{{
+			Line:   result.line,
+			Column: 2,
+			Source: result.source,
+		}}, result.errs[0].Locations)
+	}
+}
+
+func TestValidateWithRulesWithSourcesAllowsErrorsWithoutLocations(t *testing.T) {
+	s := gqlparser.MustLoadSchema(&ast.Source{
+		Name:  "schema.graphqls",
+		Input: "type Query { field: String }",
+	})
+	doc, err := parser.ParseQuery(&ast.Source{
+		Name:  "query.graphql",
+		Input: "query Query { field }",
+	})
+	require.NoError(t, err)
+
+	rule := validator.Rule{
+		Name: "NoLocationRule",
+		RuleFunc: func(_ *validator.Events, addError validator.AddErrFunc) {
+			addError(validator.Message("no location"))
+		},
+	}
+	errs := validator.ValidateWithRulesWithSources(s, doc, rules.NewRules(rule))
+
+	require.Len(t, errs, 1)
+	require.Equal(t, "no location", errs[0].Message)
+	require.Nil(t, errs[0].Locations)
 }
 
 func TestValidateWithRulesWithSourcesUsesDefaultRules(t *testing.T) {

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -91,8 +91,16 @@ type Query {
 	}
 	require.NotNil(t, found, "expected a VariablesInAllowedPosition error, got %v", errs)
 	require.Len(t, found.Locations, 2)
-	require.Equal(t, gqlerror.SourceLocation{Line: 1, Column: 14, Source: querySource}, found.Locations[0])
-	require.Equal(t, gqlerror.SourceLocation{Line: 1, Column: 56, Source: fragmentSource}, found.Locations[1])
+	require.Equal(
+		t,
+		gqlerror.SourceLocation{Line: 1, Column: 14, Source: querySource},
+		found.Locations[0],
+	)
+	require.Equal(
+		t,
+		gqlerror.SourceLocation{Line: 1, Column: 56, Source: fragmentSource},
+		found.Locations[1],
+	)
 	require.Equal(t, 1, found.Locations[0].Line)
 	require.Equal(t, 1, found.Locations[1].Line)
 	require.Equal(t, 14, found.Locations[0].Column)
@@ -133,7 +141,11 @@ func TestSingleLocationValidationRetainsSource(t *testing.T) {
 	}
 	require.NotNil(t, found)
 	require.Len(t, found.Locations, 1)
-	require.Equal(t, gqlerror.SourceLocation{Line: 1, Column: 16, Source: source}, found.Locations[0])
+	require.Equal(
+		t,
+		gqlerror.SourceLocation{Line: 1, Column: 16, Source: source},
+		found.Locations[0],
+	)
 }
 
 func TestValidateWithRulesWithSourcesRetainsOrderedCustomRuleLocations(t *testing.T) {
@@ -174,7 +186,11 @@ func TestValidateWithRulesWithSourcesRetainsOrderedCustomRuleLocations(t *testin
 		require.Len(t, errs, 2)
 		require.Equal(t, "AlphaRule", errs[0].Rule)
 		require.Equal(t, "MultiRule", errs[1].Rule)
-		require.Equal(t, []gqlerror.SourceLocation{{Line: 6, Column: 7, Source: secondSource}}, errs[0].Locations)
+		require.Equal(
+			t,
+			[]gqlerror.SourceLocation{{Line: 6, Column: 7, Source: secondSource}},
+			errs[0].Locations,
+		)
 		require.Equal(t, []gqlerror.SourceLocation{
 			{Line: 2, Column: 3, Source: firstSource},
 			{Line: 4, Column: 5, Source: secondSource},
@@ -286,7 +302,11 @@ func TestValidateWithRulesWithSourcesUsesDefaultRules(t *testing.T) {
 	}
 
 	require.NotNil(t, found)
-	require.Equal(t, []gqlerror.SourceLocation{{Line: 1, Column: 15, Source: source}}, found.Locations)
+	require.Equal(
+		t,
+		[]gqlerror.SourceLocation{{Line: 1, Column: 15, Source: source}},
+		found.Locations,
+	)
 }
 
 func TestCaptureSourceLocationsRejectsClearedLocations(t *testing.T) {

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -1,14 +1,17 @@
 package validator_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"github.com/vektah/gqlparser/v2/parser"
 	"github.com/vektah/gqlparser/v2/validator"
+	"github.com/vektah/gqlparser/v2/validator/core"
 	"github.com/vektah/gqlparser/v2/validator/rules"
 )
 
@@ -42,6 +45,179 @@ extend type Query {
 
 	require.Nil(t, validator.Validate(s, q))
 	require.Nil(t, validator.ValidateWithRules(s, q, nil))
+}
+
+func TestVariablesInAllowedPositionRetainsSourcesForMultipleLocations(t *testing.T) {
+	s := gqlparser.MustLoadSchema(&ast.Source{
+		Name: "schema.graphqls",
+		Input: `
+input Filter @oneOf {
+  byID: ID
+}
+
+type Query {
+  search(filter: Filter): String
+}
+`,
+	})
+
+	querySource := &ast.Source{
+		Name:  "queries/Search.graphql",
+		Input: "query Search($id: ID) { ...SearchFields }",
+	}
+	fragmentSource := &ast.Source{
+		Name:  "fragments/SearchFields.graphql",
+		Input: "fragment SearchFields on Query { search(filter: {byID: $id}) }",
+	}
+	query, err := parser.ParseQuery(querySource)
+	require.NoError(t, err)
+	fragment, err := parser.ParseQuery(fragmentSource)
+	require.NoError(t, err)
+
+	doc := &ast.QueryDocument{
+		Operations: query.Operations,
+		Fragments:  fragment.Fragments,
+	}
+	errs := validator.ValidateWithSources(s, doc)
+
+	var found *gqlerror.ErrorWithSources
+	for _, err := range errs {
+		if err.Rule == "VariablesInAllowedPosition" {
+			found = err
+			break
+		}
+	}
+	require.NotNil(t, found, "expected a VariablesInAllowedPosition error, got %v", errs)
+	require.Len(t, found.Locations, 2)
+	require.Equal(t, gqlerror.SourceLocation{Line: 1, Column: 14, Source: querySource}, found.Locations[0])
+	require.Equal(t, gqlerror.SourceLocation{Line: 1, Column: 56, Source: fragmentSource}, found.Locations[1])
+	require.Equal(t, 1, found.Locations[0].Line)
+	require.Equal(t, 1, found.Locations[1].Line)
+	require.Equal(t, 14, found.Locations[0].Column)
+	require.Equal(t, 56, found.Locations[1].Column)
+	require.Equal(t, fragmentSource.Name, found.Extensions["file"])
+	require.Equal(t, "queries/Search.graphql:1:14: "+found.Message, found.Error())
+
+	encoded, marshalErr := json.Marshal(found)
+	require.NoError(t, marshalErr)
+	require.JSONEq(t, `{
+		"message": "Variable \"$id\" is of type \"ID\" but must be non-nullable to be used for OneOf Input Object \"Filter\".",
+		"locations": [
+			{"line": 1, "column": 14},
+			{"line": 1, "column": 56}
+		],
+		"extensions": {"file": "fragments/SearchFields.graphql"}
+	}`, string(encoded))
+}
+
+func TestSingleLocationValidationRetainsSource(t *testing.T) {
+	s := gqlparser.MustLoadSchema(&ast.Source{
+		Name:  "schema.graphqls",
+		Input: "type Query { search: String }",
+	})
+	source := &ast.Source{
+		Name:  "queries/Search.graphql",
+		Input: "query Search { missing }",
+	}
+	query, err := parser.ParseQuery(source)
+	require.NoError(t, err)
+
+	var found *gqlerror.ErrorWithSources
+	for _, err := range validator.ValidateWithSources(s, query) {
+		if err.Rule == "FieldsOnCorrectType" {
+			found = err
+			break
+		}
+	}
+	require.NotNil(t, found)
+	require.Len(t, found.Locations, 1)
+	require.Equal(t, gqlerror.SourceLocation{Line: 1, Column: 16, Source: source}, found.Locations[0])
+}
+
+func TestValidateWithRulesWithSourcesRetainsOrderedCustomRuleLocations(t *testing.T) {
+	s := gqlparser.MustLoadSchema(&ast.Source{
+		Name:  "schema.graphqls",
+		Input: "type Query { field: String }",
+	})
+	doc, err := parser.ParseQuery(&ast.Source{
+		Name:  "query.graphql",
+		Input: "query Query { field }",
+	})
+	require.NoError(t, err)
+
+	firstSource := &ast.Source{Name: "first.graphql"}
+	secondSource := &ast.Source{Name: "second.graphql"}
+	multiRule := validator.Rule{
+		Name: "MultiRule",
+		RuleFunc: func(_ *validator.Events, addError validator.AddErrFunc) {
+			addError(
+				validator.Message("multi"),
+				core.At(&ast.Position{Src: firstSource, Line: 2, Column: 3}),
+				core.At(&ast.Position{Src: secondSource, Line: 4, Column: 5}),
+			)
+		},
+	}
+	alphaRule := validator.Rule{
+		Name: "AlphaRule",
+		RuleFunc: func(_ *validator.Events, addError validator.AddErrFunc) {
+			addError(
+				validator.Message("alpha"),
+				core.At(&ast.Position{Src: secondSource, Line: 6, Column: 7}),
+			)
+		},
+	}
+
+	for range 5 {
+		errs := validator.ValidateWithRulesWithSources(s, doc, rules.NewRules(multiRule, alphaRule))
+		require.Len(t, errs, 2)
+		require.Equal(t, "AlphaRule", errs[0].Rule)
+		require.Equal(t, "MultiRule", errs[1].Rule)
+		require.Equal(t, []gqlerror.SourceLocation{{Line: 6, Column: 7, Source: secondSource}}, errs[0].Locations)
+		require.Equal(t, []gqlerror.SourceLocation{
+			{Line: 2, Column: 3, Source: firstSource},
+			{Line: 4, Column: 5, Source: secondSource},
+		}, errs[1].Locations)
+	}
+}
+
+func TestValidateWithRulesWithSourcesUsesDefaultRules(t *testing.T) {
+	s := gqlparser.MustLoadSchema(&ast.Source{
+		Name:  "schema.graphqls",
+		Input: "type Query { field: String }",
+	})
+	source := &ast.Source{
+		Name:  "query.graphql",
+		Input: "query Query { missing }",
+	}
+	doc, err := parser.ParseQuery(source)
+	require.NoError(t, err)
+
+	var found *gqlerror.ErrorWithSources
+	for _, validationErr := range validator.ValidateWithRulesWithSources(s, doc, nil) {
+		if validationErr.Rule == "FieldsOnCorrectType" {
+			found = validationErr
+			break
+		}
+	}
+
+	require.NotNil(t, found)
+	require.Equal(t, []gqlerror.SourceLocation{{Line: 1, Column: 15, Source: source}}, found.Locations)
+}
+
+func TestCaptureSourceLocationsRejectsClearedLocations(t *testing.T) {
+	err := &gqlerror.Error{}
+	source := &ast.Source{Name: "query.graphql"}
+
+	require.PanicsWithValue(
+		t,
+		"gqlparser: captured source location 0 does not match the final error locations",
+		func() {
+			core.CaptureSourceLocations(err, func() {
+				core.At(&ast.Position{Src: source, Line: 1, Column: 2})(err)
+				err.Locations = nil
+			})
+		},
+	)
 }
 
 func TestValidationRulesAreIndependent(t *testing.T) {


### PR DESCRIPTION
Validation errors that refer to multiple AST nodes currently expose only one source document through the validator's public API. A consumer validating a document assembled from multiple files cannot identify every relevant file and position.

For example, `VariablesInAllowedPosition` compares a variable definition with a variable use in a fragment. One error can therefore refer to nodes in different source documents. Losing those source associations prevents downstream tools from rendering complete diagnostics.

This PR adds opt-in `ValidateWithSources` and `ValidateWithRulesWithSources` APIs. They return `gqlerror.SourceList` containing `ErrorWithSources` values. Each error stores its canonical locations as `[]SourceLocation`, with each entry holding line, column, and the original `*ast.Source`. Locations are captured in deterministic validation order.

Keep `Error`, `Location`, `Validate`, and `ValidateWithRules` unchanged. The source-aware type preserves the existing GraphQL JSON shape by serializing line and column only; source documents remain in memory and are omitted from JSON. Existing one-location formatting and `extensions.file` behavior remain unchanged.

Tests cover source retention and deterministic multi-location ordering, single-location behavior, cross-file built-in validation, malformed source/location associations, JSON compatibility, and legacy API compatibility.

## Compatibility

The additions are opt-in. Existing callers and serialized errors keep their current API and JSON behavior. The source-aware APIs are ready for downstream consumers that need original source documents.

## Validation

- `go test ./...`
- `go vet ./...`
- the gqlerror and validator package suites pass under the race detector