### PR TITLE
Update and pin

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,12 +1,10 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels: []
-
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.
 # Empty array means no configuration variable is allowed.
 config-variables: null
-
 # Configuration for file paths. The keys are glob patterns to match to file
 # paths relative to the repository root. The values are the configurations for
 # the file paths. Note that the path separator is always '/'.
@@ -15,5 +13,6 @@ config-variables: null
 # "ignore" is an array of regular expression patterns. Matched error messages
 # are ignored. This is similar to the "-ignore" command line option.
 paths:
+
 #  .github/workflows/**/*.yml:
 #    ignore: []

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,15 +17,15 @@ jobs:
   golangci-lint:
     strategy:
       matrix:
-        go: ["1.23", "1.24"]
+        go: ["1.26", "1.27"]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-go@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
       with:
         go-version: ${{ matrix.go }}
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v9.3.0
+      uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
       with:
         version: latest
         args: '--timeout 5m'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        go: ["1.22", "1.23"]
+        go: ["1.26", "1.27"]
         # MacOS is disabled due to the high cost multiplier on GH Actions.
         #- os: darwin
         # Windows not allowed currently because of line-ending conversion issues.
@@ -26,8 +26,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-go@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
       with:
         go-version: ${{ matrix.go }}
     - name: Unit Test Golang


### PR DESCRIPTION
This bumps the versions to test whether things work with Go 1.27 and Go 1.26

I also pinned all the GitHub actions using:
```
GOBIN=~/go/bin go install github.com/sethvargo/ratchet@latest
find . -name '*.y*l' | sort -u | grep '.github/workflows' | xargs -I {} ratchet pin '{}'
find . -name '*.y*l' -exec sed -i'' 's/ratchet:.*\/.*\@//g' {} \;
```
